### PR TITLE
Fix material parsing by id

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -1935,10 +1935,9 @@ public enum XMaterial {
      */
     @SuppressWarnings("deprecation")
     public int getId() {
-        if (this.data != 0 || (this.legacy.length != 0 && Integer.parseInt(this.legacy[0].substring(2)) >= 13)) return -1;
+        if (this.data != 0 || (this.legacy.length != 0 && this.legacy[0].contains(".") && Integer.parseInt(this.legacy[0].substring(2)) >= 13)) return -1;
         Material material = this.parseMaterial();
-        Objects.requireNonNull(material, "Unsupported material ID check: " + this.name() + " (" + this.data + ')');
-        return material.getId();
+        return material == null ? -1: material.getId();
     }
 
     /**

--- a/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -1935,7 +1935,7 @@ public enum XMaterial {
      */
     @SuppressWarnings("deprecation")
     public int getId() {
-        if (this.data != 0 || (this.legacy.length != 0 && this.legacy[0].contains(".") && Integer.parseInt(this.legacy[0].substring(2)) >= 13)) return -1;
+        if (this.data != 0 || (this.legacy.length != 0 && this.legacy[0].charAt(1) == '.' && Integer.parseInt(this.legacy[0].substring(2)) >= 13)) return -1;
         Material material = this.parseMaterial();
         return material == null ? -1: material.getId();
     }


### PR DESCRIPTION
Before on:
`XMaterial.matchXMaterial(1,0)`

`
Caused by: java.lang.NumberFormatException: For input string: "AT_ACACIA"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65) ~[?:1.8.0_252]
	at java.lang.Integer.parseInt(Integer.java:580) ~[?:1.8.0_252]
	at java.lang.Integer.parseInt(Integer.java:615) ~[?:1.8.0_252]
	at com.cryptomorin.xseries.XMaterial.getId(XMaterial.java:1937) ~[?:?]
	at com.cryptomorin.xseries.XMaterial.matchXMaterial(XMaterial.java:1665) ~[?:?]
`

After adding check whether the string contains dot:

`
Caused by: java.lang.NullPointerException: Unsupported material ID check: ANDESITE_SLAB (0)
	at java.util.Objects.requireNonNull(Objects.java:228) ~[?:1.8.0_252]
	at com.cryptomorin.xseries.XMaterial.getId(XMaterial.java:1940) ~[?:?]
	at com.cryptomorin.xseries.XMaterial.matchXMaterial(XMaterial.java:1666) ~[?:?]
`

That's reason of removing `Objects.requireNonNull`
Now works fine.
