### PR TITLE
[XItemStack] Spawner Serialize Support & Fixed Fireworks

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XBiome.java
+++ b/src/main/java/com/cryptomorin/xseries/XBiome.java
@@ -130,6 +130,7 @@ public enum XBiome {
      * @since 1.0.0
      */
     public static final List<XBiome> VALUES = Collections.unmodifiableList(Arrays.asList(values()));
+    private static final boolean supports = XMaterial.supports(16);
     @Nullable
     private final Biome biome;
 
@@ -166,7 +167,6 @@ public enum XBiome {
 
         for (int i = 0; i < len; i++) {
             char ch = name.charAt(i);
-
             if (!appendUnderline && count != 0 && (ch == '-' || ch == ' ' || ch == '_') && chs[count] != '_') appendUnderline = true;
             else {
                 if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
@@ -240,9 +240,14 @@ public enum XBiome {
         // Apparently setBiome is thread-safe.
         return CompletableFuture.runAsync(() -> {
             for (int x = 0; x < 16; x++) {
-                for (int z = 0; z < 16; z++) {
-                    Block block = chunk.getBlock(x, 0, z);
-                    if (block.getBiome() != biome) block.setBiome(biome);
+                // y loop for 1.16+ support (vertical biomes).
+                // As of now increasing it by 4 seems to work.
+                // This should be the minimal size of the vertical biomes.
+                for (int y = 0; y < (supports ? 256 : 1); y += 4) {
+                    for (int z = 0; z < 16; z++) {
+                        Block block = chunk.getBlock(x, y, z);
+                        if (block.getBiome() != biome) block.setBiome(biome);
+                    }
                 }
             }
         }).exceptionally((result) -> {
@@ -270,9 +275,14 @@ public enum XBiome {
         // Apparently setBiome is thread-safe.
         return CompletableFuture.runAsync(() -> {
             for (int x = start.getBlockX(); x < end.getBlockX(); x++) {
-                for (int z = start.getBlockZ(); z < end.getBlockZ(); z++) {
-                    Block block = new Location(start.getWorld(), x, 0, z).getBlock();
-                    if (block.getBiome() != biome) block.setBiome(biome);
+                // y loop for 1.16+ support (vertical biomes).
+                // As of now increasing it by 4 seems to work.
+                // This should be the minimal size of the vertical biomes.
+                for (int y = 0; y < (supports ? 256 : 1); y += 4) {
+                    for (int z = start.getBlockZ(); z < end.getBlockZ(); z++) {
+                        Block block = new Location(start.getWorld(), x, y, z).getBlock();
+                        if (block.getBiome() != biome) block.setBiome(biome);
+                    }
                 }
             }
         }).exceptionally((result) -> {

--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -148,6 +148,9 @@ public final class XItemStack {
                         i++;
                     }
                 }
+            } else if (state instanceof CreatureSpawner) {
+                CreatureSpawner cs = (CreatureSpawner) state;
+                config.set("spawner", cs.getSpawnedType().name());
             }
         } else if (meta instanceof EnchantmentStorageMeta) {
             EnchantmentStorageMeta book = (EnchantmentStorageMeta) meta;

--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -190,16 +190,20 @@ public final class XItemStack {
             int i = 0;
 
             for (FireworkEffect fw : firework.getEffects()) {
+                config.set("firework." + i + ".type", fw.getType().name());
                 ConfigurationSection fwc = config.getConfigurationSection("firework." + i);
-                fwc.set("type", fw.getType().name());
+                fwc.set("flicker", fw.hasFlicker());
+                fwc.set("trail", fw.hasTrail());
 
-                List<String> colors = new ArrayList<>();
-                for (Color color : fw.getColors()) colors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
-                fwc.set("colors", colors);
+                List<String> baseColors = new ArrayList<>();
+                List<String> fadeColors = new ArrayList<>();
 
-                colors.clear();
-                for (Color color : fw.getFadeColors()) colors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
-                fwc.set("fade-colors", colors);
+                for (Color color : fw.getColors()) baseColors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
+                fwc.set("base-colors", baseColors);
+
+                for (Color color : fw.getFadeColors()) fadeColors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
+                fwc.set("fade-colors", fadeColors);
+                i++;
             }
             //} else if (meta instanceof MapMeta) {
         } else if (XMaterial.supports(14)) {

--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -195,14 +195,14 @@ public final class XItemStack {
                 fwc.set("flicker", fw.hasFlicker());
                 fwc.set("trail", fw.hasTrail());
 
-                List<String> colors = new ArrayList<>();
+                List<String> baseColors = new ArrayList<>();
+                List<String> fadeColors = new ArrayList<>();
 
-                for (Color color : fw.getColors()) colors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
-                fwc.set("base-colors", colors);
+                for (Color color : fw.getColors()) baseColors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
+                fwc.set("base-colors", baseColors);
 
-                colors.clear();
-                for (Color color : fw.getFadeColors()) colors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
-                fwc.set("fade-colors", colors);
+                for (Color color : fw.getFadeColors()) fadeColors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
+                fwc.set("fade-colors", fadeColors);
                 i++;
             }
             //} else if (meta instanceof MapMeta) {

--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -62,7 +62,7 @@ import java.util.*;
  * ItemStack: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/inventory/ItemStack.html
  *
  * @author Crypto Morin
- * @version 4.0.1.3
+ * @version 4.0.1.2
  * @see XMaterial
  * @see XPotion
  * @see SkullUtils
@@ -137,15 +137,18 @@ public final class XItemStack {
             BlockStateMeta bsm = (BlockStateMeta) item.getItemMeta();
             BlockState state = bsm.getBlockState();
 
+            //shulker support
             if (XMaterial.supports(11) && state instanceof ShulkerBox) {
                 ShulkerBox box = (ShulkerBox) state;
                 int i = 0;
 
                 if (!box.getInventory().isEmpty()) {
-                    ConfigurationSection shulkerSection = config.getConfigurationSection("shulker");
                     for (ItemStack itemInBox : box.getInventory().getContents()) {
-                        if (itemInBox != null) serialize(itemInBox, shulkerSection.createSection(Integer.toString(i)));
-                        i++;
+                        if (itemInBox != null) {
+                            config.set("shulker." + i + ".material", "");
+                            serialize(itemInBox, config.getConfigurationSection("shulker." + i));
+                            i++;
+                        }
                     }
                 }
             } else if (state instanceof CreatureSpawner) {
@@ -324,17 +327,20 @@ public final class XItemStack {
                 bsm.setBlockState(spawner);
 
             } else if (XMaterial.supports(11) && state instanceof ShulkerBox) {
-                ConfigurationSection shulkerSection = config.getConfigurationSection("shulker");
-                if (shulkerSection != null) {
-                    ShulkerBox box = (ShulkerBox) state;
-                    for (String key : shulkerSection.getKeys(false)) {
-                        int slot = NumberUtils.toInt(key, 0);
-                        ItemStack itemInBox = deserialize(shulkerSection.getConfigurationSection(key));
-                        box.getInventory().setItem(slot, itemInBox);
+                    ConfigurationSection shulkerSection = config.getConfigurationSection("shulker");
+
+                    if (shulkerSection != null) {
+                        List<ItemStack> itemList = new ArrayList<>();
+                        for (String key : shulkerSection.getKeys(false)) {
+                            ConfigurationSection it =  config.getConfigurationSection("shulker." + key);
+                            ItemStack boxItem = deserialize(it);
+                            itemList.add(boxItem);
+                        }
+                        ShulkerBox box = (ShulkerBox) state;
+                        for (ItemStack boxItem : itemList) box.getInventory().addItem(boxItem);
+                        box.update(true);
+                        bsm.setBlockState(box);
                     }
-                    box.update(true);
-                    bsm.setBlockState(box);
-                }
             } else if (state instanceof Banner) {
                 Banner banner = (Banner) state;
                 ConfigurationSection patterns = config.getConfigurationSection("patterns");

--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -195,14 +195,14 @@ public final class XItemStack {
                 fwc.set("flicker", fw.hasFlicker());
                 fwc.set("trail", fw.hasTrail());
 
-                List<String> baseColors = new ArrayList<>();
-                List<String> fadeColors = new ArrayList<>();
+                List<String> colors = new ArrayList<>();
 
-                for (Color color : fw.getColors()) baseColors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
-                fwc.set("base-colors", baseColors);
+                for (Color color : fw.getColors()) colors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
+                fwc.set("base-colors", colors);
 
-                for (Color color : fw.getFadeColors()) fadeColors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
-                fwc.set("fade-colors", fadeColors);
+                colors.clear();
+                for (Color color : fw.getFadeColors()) colors.add(color.getRed() + ", " + color.getGreen() + ", " + color.getBlue());
+                fwc.set("fade-colors", colors);
                 i++;
             }
             //} else if (meta instanceof MapMeta) {

--- a/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -1642,13 +1642,13 @@ public enum XMaterial {
      * @see #matchXMaterial(ItemStack)
      * @since 2.0.0
      * @deprecated this method loops through all the available materials and matches their ID using {@link #getId()}
-     * which takes a really long time. Plugins should no longer support IDs. If you want, you can make a {@link Map} yourself.
+     * which takes a really long time. Plugins should no longer support IDs. If you want, you can make a {@link Map} cache yourself.
+     * This method obviously doesn't work for 1.13+ and will not be supported. This is only here for debugging purposes.
      */
     @Nonnull
     @Deprecated
     public static Optional<XMaterial> matchXMaterial(int id, byte data) {
         if (id < 0 || id > MAX_ID || data < 0) return Optional.empty();
-
         for (XMaterial materials : VALUES) {
             if (materials.data == data && materials.getId() == id) return Optional.of(materials);
         }


### PR DESCRIPTION
Small one but I needed it.

Also, in later versions like 1.8 on deserialize **spawner.update(true);** does not work on itemstacks. You'll get an error saying something along the lines of you can only update a Block. I fixed it so it would work for 1.8-1.16 with the following:
**bsm.setBlockState(spawner); 
item.setItemMeta(meta);**

Just thought I would let you know, I'm aware other people use this for different things so might not work correctly for them in some cases so I didn't commit it.

I also added a fix in for fireworks, I had to use two array lists because for some reason the colors were not getting serialized correctly. This is the firework I used for testing:
```
firework:
          '0':
            type: BALL_LARGE
            flicker: true
            trail: false
            base-colors:
            - 59, 81, 26
            - 65, 205, 52
            fade-colors:
            - 59, 81, 26
          '1':
            type: CREEPER
            flicker: false
            trail: true
            base-colors:
            - 65, 205, 52
            fade-colors:
            - 65, 205, 52
```