### PR TITLE
[XItemStack] Fixed Unsupported getCustomModelData() for 1.14

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -106,7 +106,9 @@ public final class XItemStack {
             config.set("damage", item.getDurability());
         }
         config.set("material", item.getType().name());
-        if (meta.hasCustomModelData()) config.set("custom-model", meta.getCustomModelData());
+        if(XMaterial.supports(14)){
+            if (meta.hasCustomModelData()) config.set("custom-model", meta.getCustomModelData());
+        }
         if (meta.isUnbreakable()) config.set("unbreakable", true);
 
         // Enchantments


### PR DESCRIPTION
The method **hasCustomModelData()** can't be used in <1.14 versions.

https://github.com/CryptoMorin/XSeries/blob/747ee8e2df3c267b5e41bd8170ada80b4e70c899/src/main/java/com/cryptomorin/xseries/XItemStack.java#L109