### PR TITLE
Pom.xml : No annotation processing is performed, set proc to none

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
+                    <proc>none</proc>
                     <source>8</source>
                     <target>8</target>
                     <excludes>


### PR DESCRIPTION
As @Im-Fran said in #116 , here it's a fix for Travis check.

According to maven doc (https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html) :
> Sets whether annotation processing is performed or not. Only applies to JDK 1.6+ If not set, both compilation and annotation processing are performed at the same time.
>
>Allowed values are:
>
>none - no annotation processing is performed.
>only - only annotation processing is done, no compilation.

Assuming Javax annotations are not build in the project.
