### PR TITLE
[ParticleDisplay] Force support and item/block datas

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -54,7 +54,7 @@ import java.util.concurrent.Callable;
  * <code>[r, g, b, size]</code>
  *
  * @author Crypto Morin
- * @version 5.0.0
+ * @version 5.0.1
  * @see XParticle
  */
 public class ParticleDisplay implements Cloneable {
@@ -74,6 +74,7 @@ public class ParticleDisplay implements Cloneable {
     public Vector rotation;
     @Nullable
     public Object data;
+    public boolean force;
 
     /**
      * Make a new instance of particle display.
@@ -86,9 +87,11 @@ public class ParticleDisplay implements Cloneable {
      * @param offsety  the y offset.
      * @param offsetz  the z offset.
      * @param extra    in most cases extra is the speed of the particles.
+     * @param force    allows the particle to be seen further away for all player regardless of their particle settings.
+     *                 Can be laggy for them.
      */
     public ParticleDisplay(@Nonnull Particle particle, @Nullable Callable<Location> locationCaller, @Nullable Location location, int count,
-                           double offsetx, double offsety, double offsetz, double extra) {
+                           double offsetx, double offsety, double offsetz, double extra, boolean force) {
         this.particle = particle;
         this.location = location;
         this.locationCaller = locationCaller;
@@ -97,6 +100,12 @@ public class ParticleDisplay implements Cloneable {
         this.offsety = offsety;
         this.offsetz = offsetz;
         this.extra = extra;
+        this.force = force;
+    }
+
+    public ParticleDisplay(@Nonnull Particle particle, @Nullable Callable<Location> locationCaller, @Nullable Location location, int count,
+                           double offsetx, double offsety, double offsetz, double extra) {
+        this(particle, locationCaller, location, count, offsetx, offsety, offsetz, extra, false);
     }
 
     public ParticleDisplay(@Nonnull Particle particle, @Nullable Location location, int count, double offsetx, double offsety, double offsetz) {
@@ -220,10 +229,12 @@ public class ParticleDisplay implements Cloneable {
         Particle particle = particleName == null ? null : XParticle.getParticle(particleName);
         int count = config.getInt("count");
         double extra = config.getDouble("extra");
+        boolean force = config.getBoolean("force");
 
         if (particle != null) display.particle = particle;
         if (count != 0) display.withCount(count);
-        if (extra != 0) display.extra = extra;
+        if (extra != 0) display.withExtra(extra);
+        if (force) display.withForce(force);
 
         String offset = config.getString("offset");
         if (offset != null) {
@@ -295,7 +306,7 @@ public class ParticleDisplay implements Cloneable {
     @Override
     public String toString() {
         return "ParticleDisplay:[Particle=" + particle + ", Count=" + count + ", Offset:{" + offsetx + ", " + offsety + ", " + offsetz + "}, Extra=" + extra
-                + ", Data=" + (data == null ? "null" : data instanceof float[] ? Arrays.toString((float[]) data) : data);
+                + "Force=" + force + ", Data=" + (data == null ? "null" : data instanceof float[] ? Arrays.toString((float[]) data) : data);
     }
 
     /**
@@ -323,6 +334,23 @@ public class ParticleDisplay implements Cloneable {
     @Nonnull
     public ParticleDisplay withExtra(double extra) {
         this.extra = extra;
+        return this;
+    }
+
+    /**
+     * A displayed particle with force can be seen further
+     * away for all player regardless of their particle
+     * settings. Force has no effect if specific players
+     * are added with {@link #spawn(Location, Player...)}.
+     *
+     * @param force the force argument.
+     *
+     * @return the same particle display.
+     * @since 5.0.1
+     */
+    @Nonnull
+    public ParticleDisplay withForce(boolean force) {
+        this.force = force;
         return this;
     }
 
@@ -449,7 +477,7 @@ public class ParticleDisplay implements Cloneable {
     @Override
     @Nonnull
     public ParticleDisplay clone() {
-        ParticleDisplay display = new ParticleDisplay(particle, locationCaller, (location == null ? null : cloneLocation(location)), count, offsetx, offsety, offsetz, extra);
+        ParticleDisplay display = new ParticleDisplay(particle, locationCaller, (location == null ? null : cloneLocation(location)), count, offsetx, offsety, offsetz, extra, force);
         if (rotation != null) display.rotation = new Vector(rotation.getX(), rotation.getY(), rotation.getZ());
         display.data = data;
         return display;
@@ -590,15 +618,15 @@ public class ParticleDisplay implements Cloneable {
                 if (ISFLAT) {
                     Particle.DustOptions dust = new Particle.DustOptions(org.bukkit.Color
                             .fromRGB((int) datas[0], (int) datas[1], (int) datas[2]), datas[3]);
-                    if (players == null) loc.getWorld().spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, dust);
+                    if (players == null) loc.getWorld().spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, dust, force);
                     else for (Player player : players) player.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, dust);
                 } else {
-                    if (players == null) loc.getWorld().spawnParticle(particle, loc, count, (int) datas[0], (int) datas[1], (int) datas[2], datas[3]);
+                    if (players == null) loc.getWorld().spawnParticle(particle, loc, count, (int) datas[0], (int) datas[1], (int) datas[2], datas[3], null, force);
                     else for (Player player : players) player.spawnParticle(particle, loc, count, (int) datas[0], (int) datas[1], (int) datas[2], datas[3]);
                 }
             }
         } else {
-            if (players == null) loc.getWorld().spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra);
+            if (players == null) loc.getWorld().spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, null, force);
             else for (Player player : players) player.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra);
         }
         return loc;

--- a/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -740,10 +740,11 @@ public class ParticleDisplay implements Cloneable {
                 else for (Player player : players) player.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra);
             }
 
-        } else if (data == null || particle.getDataType().isInstance(data)) {
-            // Checks without data or block crack, block dust, falling dust, item crack
-            if (players == null) loc.getWorld().spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, data, force);
-            else for (Player player : players) player.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, data);
+        } else {
+            // Checks without data or block crack, block dust, falling dust, item crack or if data isn't right type
+            Object datas = particle.getDataType().isInstance(data) ? data : null;
+            if (players == null) loc.getWorld().spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, datas, force);
+            else for (Player player : players) player.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, datas);
         }
         return loc;
     }

--- a/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
@@ -2040,8 +2040,8 @@ public final class XParticle {
                 }
                 java.awt.Color color = new java.awt.Color((i << 21) + (i << 10) + i * 8);
 
-                display.data = new float[]{color.getRed(), color.getGreen(), color.getBlue(), 0.8f};
-                display.spawn(x, y, 0);
+                display.withColor(color, 0.8f)
+                       .spawn(x, y, 0);
             }
         }
     }


### PR DESCRIPTION
There are two added features :
- Force support, like I did in #116.
- Support for BLOCK_CRACK, BLOCK_DUST, FALLING_DUST and ITEM_CRACK particles, customizable with data field and methods withBlock and withItem (#114). **In theory, the feature supports version 1.12 but I have not tested it.**
- It "fixed" issue #114 since it also allows particles like SPELL_MOB or SPELL_MOB_AMBIENT to use colors in the same way as REDSTONE does. When SPELL_MOB or 1.12 REDSTONE has count=0 (directionnal), the offset becomes the color and the speed becomes other thing, for REDSTONE it's size but for SPELL_MOB it's a mix of offset, speed and saturation color. In 1.13, REDSTONE changed to get other parameters, but not SPELL_MOB.

-> Tested in 1.16.5 with some recent Paper builds in java 15, but not in other versions ! (In 2 or 3 weeks, if this pr hasn't been merged yet, I'll test it on other versions)


Commit description : 
>• BLOCK_CRACK, BLOCK_DUST, FALLING_DUST and ITEM_CRACK are now supported in the data field.
>• Data field becomes private to prevent users from freely changing its value. A getter is added and methods withColor, withBlock and withItem modify this value.
>• Method withEntity shouldn't get a null entity to avoid a NullPointerException everytime the entity is null.
>• Deserialisation with edit method is adapted to blocks and item supports. Not tested in 1.12 or less.
>• Spawn particle method is also adapted. It can spawn MOB_EFFECT particle with color with in same way as it does with 1.12 REDSTONE particle (color becomes the offset) if count=0.