### PR TITLE
Added serialization support for Maps

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -99,7 +99,7 @@ public final class XItemStack {
         ItemMeta meta = item.getItemMeta();
 
         // Material
-        config.set("material", item.getType().name());
+        config.set("material", XMaterial.matchXMaterial(item).name());
 
         // Amount
         if (item.getAmount() > 1) config.set("amount", item.getAmount());
@@ -778,11 +778,17 @@ public final class XItemStack {
         return deserialize(mapToConfigSection(serializedItem));
     }
 
+    /**
+     * Converts a {@code Map<?, ?>} into a {@code ConfigurationSection}.
+     *
+     * @param map the map to convert.
+     * @return a {@code ConfigurationSection} containing the map values.
+     */
     @Nonnull
-    private static ConfigurationSection mapToConfigSection(@Nonnull Map<?, ?> serializedItem) {
+    private static ConfigurationSection mapToConfigSection(@Nonnull Map<?, ?> map) {
         final ConfigurationSection config = new MemoryConfiguration();
 
-        for(Map.Entry<?, ?> entry : serializedItem.entrySet()) {
+        for(Map.Entry<?, ?> entry : map.entrySet()) {
             String key = entry.getKey().toString();
             Object value = entry.getValue();
             if (value == null) continue;
@@ -795,6 +801,12 @@ public final class XItemStack {
         return config;
     }
 
+    /**
+     * Converts a {@code ConfigurationSection} into a {@code Map<String, Object>}.
+     *
+     * @param config the configuration section to convert.
+     * @return a {@code Map<String, Object>} containing the configuration section values.
+     */
     @Nonnull
     private static Map<String, Object> configSectionToMap(@Nonnull ConfigurationSection config) {
         final Map<String, Object> map = new LinkedHashMap<>();

--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -788,7 +788,7 @@ public final class XItemStack {
             if (value == null) continue;
 
             if (value instanceof Map<?, ?>) {
-                value = mapToConfigSection((Map<?, ?>)entry.getValue());
+                value = mapToConfigSection((Map<?, ?>)value);
             }
             config.set(key, value);
         }

--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -37,7 +37,6 @@ import org.bukkit.block.banner.Pattern;
 import org.bukkit.block.banner.PatternType;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.MemoryConfiguration;
-import org.bukkit.configuration.MemorySection;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Axolotl;
 import org.bukkit.entity.EntityType;
@@ -371,11 +370,7 @@ public final class XItemStack {
         // Material
         String material = config.getString("material");
         if (material == null) return null;
-        Optional<XMaterial> matOpt = XMaterial.matchXMaterial(material);
-        if (!matOpt.isPresent()) return null;
-
-        // Build
-        ItemStack item = matOpt.get().parseItem();
+        ItemStack item = XMaterial.matchXMaterial(material).map(XMaterial::parseItem).orElse(null);
         if (item == null) return null;
         ItemMeta meta = item.getItemMeta();
 


### PR DESCRIPTION
As mentioned [here](https://github.com/CryptoMorin/XSeries/issues/142), here's the PR introducing support for item serialization and deserialization to and from `Map`. The new code works just fine as far as I could test, both serialization methods (using `ConfigurationSection` and passing a `Map<String, Object>` directly) did produce the same output.

I got some NPEs along the process and did fix all of them in one commit, the exceptions I got can be seen below and validated as well. Feel free to modify anything, or ask for modifications.

## Features

- Added serialization and deserialization support for `Map<String, Object>`.

## Fixes

- Fixed #141 
- Fixed NPE when serializing items that had AttributeModifiers that weren't bound to a specific slot (so `slot` was `null`).
- Fixed NPE when deserializing items that had AttributeModifier, that was happening because instead of querying the specific config entry of that Attribute, the code was querying the map of attributes, which of course does not have any attribute of specific properties on its root.