### PR TITLE
[XParticle] Add DustTransition compatibility for ParticleDisplay

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -74,11 +74,11 @@ public class ParticleDisplay implements Cloneable {
     private static final boolean ISFLAT = XParticle.getParticle("FOOTSTEP") == null;
     /**
      * Checks if spawn methods should use particle data classes such as {@link org.bukkit.Particle.DustTransition}
-     * which is only available from 1.17+ (VIBRATION was released in 1.17)
+     * which is only available from 1.17+ (DUST_COLOR_TRANSITION was released in 1.17)
      *
      * @since 8.6.0.0.1
      */
-    private static final boolean ISFLAT2 = XParticle.getParticle("VIBRATION") != null;
+    private static final boolean ISFLAT2 = XParticle.getParticle("DUST_COLOR_TRANSITION") != null;
     private static final Axis[] DEFAULT_ROTATION_ORDER = {Axis.X, Axis.Y, Axis.Z};
     private static final Particle DEFAULT_PARTICLE = Particle.CLOUD;
 


### PR DESCRIPTION
Hello !

A small pull request to add compatibility for new `DUST_COLOR_TRANSITION` particle releaded in 1.17. The basic idea is to add three new numbers in the `float[]` data and get it back when we detect on spawn that we can add DustTransition instance.

I also fixed a small issue with the `edit` method when called from `fromConfig`. With a new ParticleDisplay instance, `display.data instanceof float[]` was always false so if the config had `size` and `color` values, 1 was the only reachable size even if the config set it to another value (because it was set to 1 and check if size is set is done after data instance float[]).

In deserialization, the second color for transition colors follows the idea of the first one : if `color` has 1 or 3 strings it's one full color (get with Color.decode(String)) or R G B. If `color` has 2 or 6 strings, it's the same but color1 color2 or R1 G1 B1 R2 G2 B2.

Note that the `BLOCK_MARKER` particle from 1.18 works thanks to BlockData data (method `withBlock(BlockData)`). Furthermore, VIBRATION particles (1.17+) won't work at all because it needs Vibration instance as data and it's not easy to handle like that (Location origin, Location destination, int arrivalTime). Maybe if I find a clean way to introduce it, I'll PR it.

(Yeah I wrote understable instead of understandable :p)