### PR TITLE
Added EnumUtils which removes the code duplication of creating a display name for enums.

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XEnchantment.java
+++ b/src/main/java/com/cryptomorin/xseries/XEnchantment.java
@@ -31,8 +31,10 @@ import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import static java.util.stream.Collectors.joining;
+
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Enchantment support with multiple aliases.
@@ -308,7 +310,7 @@ public enum XEnchantment {
     public String toString() {
         return Arrays.stream(name().split("_"))
                 .map(t -> t.charAt(0) + t.substring(1).toLowerCase())
-                .collect(Collectors.joining(" "));
+                .collect(joining(" "));
     }
 
     /**

--- a/src/main/java/com/cryptomorin/xseries/XEnchantment.java
+++ b/src/main/java/com/cryptomorin/xseries/XEnchantment.java
@@ -21,6 +21,7 @@
  */
 package com.cryptomorin.xseries;
 
+import com.cryptomorin.xseries.utils.EnumUtils;
 import com.google.common.base.Enums;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -31,8 +32,6 @@ import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import static java.util.stream.Collectors.joining;
 
 import java.util.*;
 
@@ -308,9 +307,7 @@ public enum XEnchantment {
     @Override
     @Nonnull
     public String toString() {
-        return Arrays.stream(name().split("_"))
-                .map(t -> t.charAt(0) + t.substring(1).toLowerCase())
-                .collect(joining(" "));
+        return EnumUtils.getDisplayName(this);
     }
 
     /**

--- a/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -22,6 +22,7 @@
  */
 package com.cryptomorin.xseries;
 
+import com.cryptomorin.xseries.utils.EnumUtils;
 import com.google.common.base.Enums;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -34,8 +35,6 @@ import org.bukkit.potion.Potion;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import static java.util.stream.Collectors.joining;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -2075,9 +2074,7 @@ public enum XMaterial {
     @Override
     @Nonnull
     public String toString() {
-        return Arrays.stream(name().split("_"))
-                .map(t -> t.charAt(0) + t.substring(1).toLowerCase())
-                .collect(joining(" "));
+    	return EnumUtils.getDisplayName(this);
     }
 
     /**

--- a/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -34,12 +34,14 @@ import org.bukkit.potion.Potion;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import static java.util.stream.Collectors.joining;
+
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
 
 /**
  * <b>XMaterial</b> - Data Values/Pre-flattening<br>
@@ -2075,7 +2077,7 @@ public enum XMaterial {
     public String toString() {
         return Arrays.stream(name().split("_"))
                 .map(t -> t.charAt(0) + t.substring(1).toLowerCase())
-                .collect(Collectors.joining(" "));
+                .collect(joining(" "));
     }
 
     /**

--- a/src/main/java/com/cryptomorin/xseries/XPotion.java
+++ b/src/main/java/com/cryptomorin/xseries/XPotion.java
@@ -21,6 +21,7 @@
  */
 package com.cryptomorin.xseries;
 
+import com.cryptomorin.xseries.utils.EnumUtils;
 import com.google.common.base.Strings;
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -34,8 +35,6 @@ import org.bukkit.potion.PotionType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import static java.util.stream.Collectors.joining;
 
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
@@ -486,9 +485,7 @@ public enum XPotion {
      */
     @Override
     public String toString() {
-        return Arrays.stream(name().split("_"))
-                .map(t -> t.charAt(0) + t.substring(1).toLowerCase())
-                .collect(joining(" "));
+    	return EnumUtils.getDisplayName(this);
     }
 
     /**

--- a/src/main/java/com/cryptomorin/xseries/XPotion.java
+++ b/src/main/java/com/cryptomorin/xseries/XPotion.java
@@ -34,10 +34,11 @@ import org.bukkit.potion.PotionType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import static java.util.stream.Collectors.joining;
+
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
-
 /**
  * Potion type support for multiple aliases.
  * Uses EssentialsX potion list for aliases.
@@ -487,7 +488,7 @@ public enum XPotion {
     public String toString() {
         return Arrays.stream(name().split("_"))
                 .map(t -> t.charAt(0) + t.substring(1).toLowerCase())
-                .collect(Collectors.joining(" "));
+                .collect(joining(" "));
     }
 
     /**

--- a/src/main/java/com/cryptomorin/xseries/XSound.java
+++ b/src/main/java/com/cryptomorin/xseries/XSound.java
@@ -35,9 +35,11 @@ import org.bukkit.scheduler.BukkitTask;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import static java.util.stream.Collectors.joining;
+
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * <b>XSound</b> - Universal Minecraft Sound Support<br>
@@ -1775,7 +1777,7 @@ public enum XSound {
     public String toString() {
         return Arrays.stream(name().split("_"))
                 .map(t -> t.charAt(0) + t.substring(1).toLowerCase())
-                .collect(Collectors.joining(" "));
+                .collect(joining(" "));
     }
 
     /**

--- a/src/main/java/com/cryptomorin/xseries/XSound.java
+++ b/src/main/java/com/cryptomorin/xseries/XSound.java
@@ -21,6 +21,7 @@
  */
 package com.cryptomorin.xseries;
 
+import com.cryptomorin.xseries.utils.EnumUtils;
 import com.google.common.base.Enums;
 import com.google.common.base.Strings;
 import org.bukkit.Instrument;
@@ -35,8 +36,6 @@ import org.bukkit.scheduler.BukkitTask;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import static java.util.stream.Collectors.joining;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -1775,9 +1774,7 @@ public enum XSound {
      */
     @Override
     public String toString() {
-        return Arrays.stream(name().split("_"))
-                .map(t -> t.charAt(0) + t.substring(1).toLowerCase())
-                .collect(joining(" "));
+        return EnumUtils.getDisplayName(this);
     }
 
     /**

--- a/src/main/java/com/cryptomorin/xseries/utils/EnumUtils.java
+++ b/src/main/java/com/cryptomorin/xseries/utils/EnumUtils.java
@@ -1,0 +1,15 @@
+package com.cryptomorin.xseries.utils;
+
+import static java.util.stream.Collectors.joining;
+
+import java.util.Arrays;
+
+public class EnumUtils 
+{
+	public static <E extends Enum<?>> String getDisplayName(E enumInstance) 
+	{
+		return Arrays.stream(enumInstance.name().split("_"))
+                .map(word -> word.charAt(0) + word.substring(1).toLowerCase())
+                .collect(joining(" "));
+	}
+}

--- a/src/test/DifferenceHelper.java
+++ b/src/test/DifferenceHelper.java
@@ -3,6 +3,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.potion.PotionEffectType;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -13,7 +15,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class DifferenceHelper {
     /**
@@ -39,7 +40,7 @@ public class DifferenceHelper {
                 .filter(x -> x.getType() == clazz)
                 .filter(x -> Modifier.isStatic(x.getModifiers()))
                 .map(Field::getName)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     /**
@@ -60,7 +61,7 @@ public class DifferenceHelper {
      */
     public static <S extends Enum<S>, E extends Enum<E>>
     void writeDifference(Path path, Class<S> system, Class<E> custom, java.util.function.Predicate<String> ignore) {
-        List<String> enumNames = Arrays.stream(system.getEnumConstants()).map(Enum::name).collect(Collectors.toList());
+        List<String> enumNames = Arrays.stream(system.getEnumConstants()).map(Enum::name).collect(toList());
         writeDifference(path, enumNames, custom, ignore);
     }
 


### PR DESCRIPTION
This PR initially started with statically importing all **Collectors**, but then I realized they were all involved in generating elegant display names for enums - so instead I added a class that removes all the code duplications.