### PR TITLE
Fix setting skull owner using UUID pre-1.13

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/SkullUtils.java
+++ b/src/main/java/com/cryptomorin/xseries/SkullUtils.java
@@ -139,7 +139,7 @@ public class SkullUtils {
         SkullMeta meta = (SkullMeta) head.getItemMeta();
 
         if (SUPPORTS_UUID) meta.setOwningPlayer(Bukkit.getOfflinePlayer(id));
-        else meta.setOwner(id.toString());
+        else meta.setOwner(Bukkit.getOfflinePlayer(id).getName());
 
         head.setItemMeta(meta);
         return head;


### PR DESCRIPTION
Fixed old version skull issue. Changed id.toString() to Bukkit.getOfflinePlayer(id).getName() because old version doesn't support uuid to owner skin. It only supports player name.