### PR TITLE
Split runnables from task in XParticle

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
@@ -692,9 +692,12 @@ public final class XParticle {
             final double rateDiv = Math.PI / rate;
             int timer = time;
             double theta = 0;
+            boolean done = false;
 
             @Override
             public boolean getAsBoolean() {
+                if (done) return false;
+
                 for (int i = 0; i < points; i++) {
                     // Spawn a circle.
                     double angle = PII * ((double) i / points);
@@ -729,7 +732,12 @@ public final class XParticle {
                 }
 
                 theta += rateDiv;
-                return --timer > 0;
+
+                if (--timer <= 0) {
+                    done = true;
+                    return false;
+                }
+                return true;
             }
         };
     }
@@ -1333,9 +1341,12 @@ public final class XParticle {
                                     double offsetx, double offsety, double offsetz, ParticleDisplay display) {
         return new BooleanSupplier() {
             int count = amount;
+            boolean done = false;
 
             @Override
             public boolean getAsBoolean() {
+                if (done) return false;
+
                 int frame = rate;
 
                 while (frame-- != 0) {
@@ -1347,7 +1358,11 @@ public final class XParticle {
                     line(start, end, 0.1, display);
                 }
 
-                return count-- > 0;
+                if (count-- <= 0) {
+                    done = true;
+                    return false;
+                }
+                return true;
             }
         };
     }
@@ -1480,9 +1495,12 @@ public final class XParticle {
             double dynamicRadius = fadeDown ? 0 : radius;
             boolean center = !fadeDown;
             double y = 0;
+            boolean done = false;
 
             @Override
             public boolean getAsBoolean() {
+                if (done) return false;
+
                 int repeat = speed;
                 while (repeat-- > 0) {
                     y += rate;
@@ -1504,8 +1522,14 @@ public final class XParticle {
                         display.rotate(0, -angle, 0);
                         tempString--;
                     }
+
+                    if (y > height) {
+                        done = true;
+                        return false;
+                    }
                 }
-                return y <= height;
+
+                return true;
             }
         };
     }
@@ -1669,9 +1693,12 @@ public final class XParticle {
         return new BooleanSupplier() {
             double y = 0;
             int nucleotideDist = 0;
+            boolean done = false;
 
             @Override
             public boolean getAsBoolean() {
+                if (done) return false;
+
                 int repeat = speed;
                 while (repeat-- != 0) {
                     y += rate;
@@ -1707,8 +1734,14 @@ public final class XParticle {
                             line(nucleotide2, midPointBond, rate - 0.1, guanine);
                         }
                     }
+
+                    if (y > height) {
+                        done = true;
+                        return false;
+                    }
                 }
-                return y < height;
+
+                return true;
             }
         };
     }
@@ -2152,9 +2185,12 @@ public final class XParticle {
         return new BooleanSupplier() {
             double angle = 0;
             long repeat = 0;
+            boolean done = false;
 
             @Override
             public boolean getAsBoolean() {
+                if (done) return false;
+
                 double cos = Math.cos(angle);
                 double sin = Math.sin(angle);
 
@@ -2207,6 +2243,7 @@ public final class XParticle {
                 }
 
                 if (++repeat > ticks) {
+                    done = true;
                     return false;
                 } else {
                     angle += speed;
@@ -2389,9 +2426,12 @@ public final class XParticle {
             tasks.add(new BooleanSupplier() {
                 double vein = 0;
                 double theta = 0;
+                boolean done = false;
 
                 @Override
                 public boolean getAsBoolean() {
+                    if (done) return false;
+
                     int repeat = speed;
                     while (repeat-- != 0) {
                         theta += rateDiv;
@@ -2415,7 +2455,11 @@ public final class XParticle {
                         }
                     }
 
-                    return theta < PII;
+                    if (theta >= PII) {
+                        done = true;
+                        return false;
+                    }
+                    return true;
                 }
             });
         }
@@ -2637,9 +2681,12 @@ public final class XParticle {
             final double addition = Math.PI * 0.1;
             final double rateDiv = Math.PI / rate;
             double times = Math.PI / 4;
+            boolean done = false;
 
             @Override
             public boolean getAsBoolean() {
+                if (done) return false;
+
                 times += addition;
                 for (double theta = 0; theta <= PII; theta += rateDiv) {
                     double x = times * Math.cos(theta);
@@ -2653,7 +2700,11 @@ public final class XParticle {
                     z = times * Math.sin(theta);
                     secDisplay.spawn(x, y, z);
                 }
-                return times <= 20;
+                if (times > 20) {
+                    done = true;
+                    return false;
+                }
+                return true;
             }
         };
     }
@@ -2810,15 +2861,23 @@ public final class XParticle {
                                                   int repeat, int quality, int speed, float size) {
         return new BooleanSupplier() {
             int times = repeat;
+            boolean done = false;
 
             @Override
             public boolean getAsBoolean() {
+                if (done) return false;
+
                 try {
                     displayRenderedImage(render, location.call(), quality, speed, size);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-                return times-- > 0;
+
+                if (times-- <= 0) {
+                    done = true;
+                    return false;
+                }
+                return true;
             }
         };
     }

--- a/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
@@ -951,20 +951,18 @@ public final class XParticle {
      * This will move the shape around in an area randomly while rotating them.
      * The position of the shape will be randomized positively and negatively by the offset parameters on each axis.
      *
-     * @param plugin   the schedule handler.
-     * @param update   the timer period in ticks.
      * @param rate     the distance between each location. Recommended value is 5.
      * @param runnable the particles to spawn.
      * @param displays the display references used to spawn particles in the runnable.
      *
-     * @return the async task handling the movement.
-     * @see #rotateAround(Plugin, long, double, double, double, double, Runnable, ParticleDisplay...)
-     * @see #guard(Plugin, long, double, double, double, double, Runnable, ParticleDisplay...)
+     * @return the runnable handling the movement.
+     * @see #rotateAround(double, double, double, double, Runnable, ParticleDisplay...)
+     * @see #guard(double, double, double, double, Runnable, ParticleDisplay...)
      * @since 1.0.0
      */
-    public static BukkitTask moveRotatingAround(Plugin plugin, long update, double rate, double offsetx, double offsety, double offsetz,
+    public static Runnable moveRotatingAround(double rate, double offsetx, double offsety, double offsetz,
                                                 Runnable runnable, ParticleDisplay... displays) {
-        return new BukkitRunnable() {
+        return new Runnable() {
             double rotation = 180;
 
             @Override
@@ -984,11 +982,11 @@ public final class XParticle {
                 runnable.run();
                 for (ParticleDisplay display : displays) display.getLocation().subtract(vector);
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, update);
+        };
     }
 
     /**
-     * This will move the particle around in an area randomly.
+     * This will move the shape around in an area randomly while rotating them.
      * The position of the shape will be randomized positively and negatively by the offset parameters on each axis.
      *
      * @param plugin   the schedule handler.
@@ -1002,9 +1000,27 @@ public final class XParticle {
      * @see #guard(Plugin, long, double, double, double, double, Runnable, ParticleDisplay...)
      * @since 1.0.0
      */
-    public static BukkitTask moveAround(Plugin plugin, long update, double rate, double endRate, double offsetx, double offsety, double offsetz,
+    public static BukkitTask moveRotatingAround(Plugin plugin, long update, double rate, double offsetx, double offsety, double offsetz,
+                                                Runnable runnable, ParticleDisplay... displays) {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, moveRotatingAround(rate, offsetx, offsety, offsetz, runnable, displays), 0, update);
+    }
+
+    /**
+     * This will move the particle around in an area randomly.
+     * The position of the shape will be randomized positively and negatively by the offset parameters on each axis.
+     *
+     * @param rate     the distance between each location. Recommended value is 5.
+     * @param runnable the particles to spawn.
+     * @param displays the display references used to spawn particles in the runnable.
+     *
+     * @return the runnable handling the movement.
+     * @see #rotateAround(double, double, double, double, Runnable, ParticleDisplay...)
+     * @see #guard(double, double, double, double, Runnable, ParticleDisplay...)
+     * @since 1.0.0
+     */
+    public static Runnable moveAround(double rate, double endRate, double offsetx, double offsety, double offsetz,
                                         Runnable runnable, ParticleDisplay... displays) {
-        return new BukkitRunnable() {
+        return new Runnable() {
             double multiplier = 0;
             boolean opposite = false;
 
@@ -1027,7 +1043,27 @@ public final class XParticle {
                     if (multiplier >= endRate) opposite = true;
                 }
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, update);
+        };
+    }
+
+    /**
+     * This will move the particle around in an area randomly.
+     * The position of the shape will be randomized positively and negatively by the offset parameters on each axis.
+     *
+     * @param plugin   the schedule handler.
+     * @param update   the timer period in ticks.
+     * @param rate     the distance between each location. Recommended value is 5.
+     * @param runnable the particles to spawn.
+     * @param displays the display references used to spawn particles in the runnable.
+     *
+     * @return the async task handling the movement.
+     * @see #rotateAround(Plugin, long, double, double, double, double, Runnable, ParticleDisplay...)
+     * @see #guard(Plugin, long, double, double, double, double, Runnable, ParticleDisplay...)
+     * @since 1.0.0
+     */
+    public static BukkitTask moveAround(Plugin plugin, long update, double rate, double endRate, double offsetx, double offsety, double offsetz,
+                                        Runnable runnable, ParticleDisplay... displays) {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, moveAround(rate, endRate, offsetx, offsety, offsetz, runnable, displays), 0, update);
     }
 
     /**
@@ -1047,20 +1083,18 @@ public final class XParticle {
      * This will rotate the shape around in an area randomly.
      * The position of the shape will be randomized positively and negatively by the offset parameters on each axis.
      *
-     * @param plugin   the schedule handler.
-     * @param update   the timer period in ticks.
      * @param rate     the distance between each location. Recommended value is 5.
      * @param runnable the particles to spawn.
      * @param displays the displays references used to spawn particles in the runnable.
      *
-     * @return the async task handling the movement.
-     * @see #moveRotatingAround(Plugin, long, double, double, double, double, Runnable, ParticleDisplay...)
-     * @see #guard(Plugin, long, double, double, double, double, Runnable, ParticleDisplay...)
+     * @return the runnable handling the movement.
+     * @see #moveRotatingAround(double, double, double, double, Runnable, ParticleDisplay...)
+     * @see #guard(double, double, double, double, Runnable, ParticleDisplay...)
      * @since 1.0.0
      */
-    public static BukkitTask rotateAround(Plugin plugin, long update, double rate, double offsetx, double offsety, double offsetz,
+    public static Runnable rotateAround(double rate, double offsetx, double offsety, double offsetz,
                                           Runnable runnable, ParticleDisplay... displays) {
-        return new BukkitRunnable() {
+        return new Runnable() {
             double rotation = 180;
 
             @Override
@@ -1074,7 +1108,73 @@ public final class XParticle {
                 for (ParticleDisplay display : displays) display.rotate(vector);
                 runnable.run();
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, update);
+        };
+    }
+
+    /**
+     * This will rotate the shape around in an area randomly.
+     * The position of the shape will be randomized positively and negatively by the offset parameters on each axis.
+     *
+     * @param plugin   the schedule handler.
+     * @param update   the timer period in ticks.
+     * @param rate     the distance between each location. Recommended value is 5.
+     * @param runnable the particles to spawn.
+     * @param displays the displays references used to spawn particles in the runnable.
+     *
+     * @return the async task handling the movement.
+     * @see #moveRotatingAround(Plugin, long, double, double, double, double, Runnable, ParticleDisplay...)
+     * @see #guard(Plugin, long, double, double, double, double, Runnable, ParticleDisplay...)
+     * @since 1.0.0
+     */
+    public static BukkitTask rotateAround(Plugin plugin, long update, double rate, double offsetx, double offsety, double offsetz,
+                                          Runnable runnable, ParticleDisplay... displays) {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, rotateAround(rate, offsetx, offsety, offsetz, runnable, displays), 0, update);
+    }
+
+    /**
+     * This will move the particle around in an area randomly.
+     * The position of the shape will be randomized positively and negatively by the offset parameters on each axis.
+     * Note that the ParticleDisplays used in runnable and displays options must be from the same reference.
+     * <p>
+     * <b>Example</b>
+     * <pre>
+     *     ParticleDisplays display = new ParticleDisplay(...);
+     *     {@code WRONG: moveAround(5, 1.5, 1.5, 1.5, () -> circle(1, 10, new ParticleDisplay(...)), display);}
+     *     {@code CORRECT: moveAround(5, 1.5, 1.5, 1.5, () -> circle(1, 10, display), display);}
+     * </pre>
+     *
+     * @param rate     the distance between each location. Recommended value is 5.
+     * @param runnable the particles to spawn.
+     * @param displays the displays references used to spawn particles in the runnable.
+     *
+     * @return the async task handling the movement.
+     * @see #rotateAround(double, double, double, double, Runnable, ParticleDisplay...)
+     * @see #moveRotatingAround(double, double, double, double, Runnable, ParticleDisplay...)
+     * @since 1.0.0
+     */
+    public static Runnable guard(double rate, double offsetx, double offsety, double offsetz,
+                                   Runnable runnable, ParticleDisplay... displays) {
+        return new Runnable() {
+            double rotation = 180;
+
+            @Override
+            public void run() {
+                rotation += rate;
+                double x = Math.toRadians((90 + rotation) * offsetx);
+                double y = Math.toRadians((60 + rotation) * offsety);
+                double z = Math.toRadians((30 + rotation) * offsetz);
+
+                Vector vector = new Vector(offsetx * Math.PI, offsety * Math.PI, offsetz * Math.PI);
+                ParticleDisplay.rotateAround(vector, x, y, z);
+
+                for (ParticleDisplay display : displays) {
+                    display.setRotation(new Vector(x, y, z));
+                    display.getLocation().add(vector);
+                }
+                runnable.run();
+                for (ParticleDisplay display : displays) display.getLocation().subtract(vector);
+            }
+        };
     }
 
     /**
@@ -1102,27 +1202,7 @@ public final class XParticle {
      */
     public static BukkitTask guard(Plugin plugin, long update, double rate, double offsetx, double offsety, double offsetz,
                                    Runnable runnable, ParticleDisplay... displays) {
-        return new BukkitRunnable() {
-            double rotation = 180;
-
-            @Override
-            public void run() {
-                rotation += rate;
-                double x = Math.toRadians((90 + rotation) * offsetx);
-                double y = Math.toRadians((60 + rotation) * offsety);
-                double z = Math.toRadians((30 + rotation) * offsetz);
-
-                Vector vector = new Vector(offsetx * Math.PI, offsety * Math.PI, offsetz * Math.PI);
-                ParticleDisplay.rotateAround(vector, x, y, z);
-
-                for (ParticleDisplay display : displays) {
-                    display.setRotation(new Vector(x, y, z));
-                    display.getLocation().add(vector);
-                }
-                runnable.run();
-                for (ParticleDisplay display : displays) display.getLocation().subtract(vector);
-            }
-        }.runTaskTimerAsynchronously(plugin, 0L, update);
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, guard(rate, offsetx, offsety, offsetz, runnable, displays), 0, update);
     }
 
     /**
@@ -1240,21 +1320,22 @@ public final class XParticle {
     /**
      * Spawns animated spikes randomly spreading at the end location.
      *
-     * @param plugin    the timer handler.
      * @param amount    the amount of spikes to spawn.
      * @param rate      rate of spike line points.
      * @param start     start location of spikes.
      * @param originEnd end location of spikes.
      *
+     * @return the runnable. It will return false when the amount of spikes has been reached.
+     *
      * @since 1.0.0
      */
-    public static BukkitTask spread(Plugin plugin, int amount, int rate, Location start, Location originEnd,
+    public static BooleanSupplier spread(int amount, int rate, Location start, Location originEnd,
                                     double offsetx, double offsety, double offsetz, ParticleDisplay display) {
-        return new BukkitRunnable() {
+        return new BooleanSupplier() {
             int count = amount;
 
             @Override
-            public void run() {
+            public boolean getAsBoolean() {
                 int frame = rate;
 
                 while (frame-- != 0) {
@@ -1266,9 +1347,33 @@ public final class XParticle {
                     line(start, end, 0.1, display);
                 }
 
-                if (count-- == 0) cancel();
+                return count-- > 0;
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, 1L);
+        };
+    }
+
+    /**
+     * Spawns animated spikes randomly spreading at the end location.
+     *
+     * @param plugin    the timer handler.
+     * @param amount    the amount of spikes to spawn.
+     * @param rate      rate of spike line points.
+     * @param start     start location of spikes.
+     * @param originEnd end location of spikes.
+     *
+     * @since 1.0.0
+     */
+    public static BukkitTask spread(Plugin plugin, int amount, int rate, Location start, Location originEnd,
+                                    double offsetx, double offsety, double offsetz, ParticleDisplay display) {
+        BooleanSupplier spread = spread(amount, rate, start, originEnd, offsetx, offsety, offsetz, display);
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!spread.getAsBoolean()) {
+                    cancel();
+                }
+            }
+        }.runTaskTimerAsynchronously(plugin, 0, 1);
     }
 
     /**
@@ -1300,7 +1405,6 @@ public final class XParticle {
     /**
      * Spawns multiple animated atomic-like circles rotating around in their orbit.
      *
-     * @param plugin the timer handler.
      * @param orbits the orbits of the atom.
      * @param radius the radius of the atom orbits.
      * @param rate   the rate of orbit points.
@@ -1308,8 +1412,8 @@ public final class XParticle {
      * @see #atom(int, double, double, ParticleDisplay, ParticleDisplay)
      * @since 1.0.0
      */
-    public static BukkitTask atomic(Plugin plugin, int orbits, double radius, double rate, ParticleDisplay orbit) {
-        return new BukkitRunnable() {
+    public static Runnable atomic(int orbits, double radius, double rate, ParticleDisplay orbit) {
+        return new Runnable() {
             final double rateDiv = Math.PI / rate;
             final double dist = Math.PI / orbits;
             double theta = 0;
@@ -1328,13 +1432,27 @@ public final class XParticle {
                     orbital--;
                 }
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, 1L);
+        };
+    }
+
+    /**
+     * Spawns multiple animated atomic-like circles rotating around in their orbit.
+     *
+     * @param plugin the timer handler.
+     * @param orbits the orbits of the atom.
+     * @param radius the radius of the atom orbits.
+     * @param rate   the rate of orbit points.
+     *
+     * @see #atom(int, double, double, ParticleDisplay, ParticleDisplay)
+     * @since 1.0.0
+     */
+    public static BukkitTask atomic(Plugin plugin, int orbits, double radius, double rate, ParticleDisplay orbit) {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, atomic(orbits, radius, rate, orbit), 0, 1);
     }
 
     /**
      * Spawns animated helix shapes.
      *
-     * @param plugin    the timer handler.
      * @param strings   the amount of helix strings. The rotation angle will split equally for each.
      * @param radius    the radius of the helix.
      * @param rate      the rate of helix points.
@@ -1344,13 +1462,13 @@ public final class XParticle {
      * @param fadeUp    helix radius will decrease to zero as it gets closer to the top.
      * @param fadeDown  helix radius will increase to the original radius as it gets closer to the center.
      *
-     * @return the animation task.
-     * @see #dnaReplication(Plugin, double, double, int, double, int, int, ParticleDisplay)
+     * @return the animation runnable. It will return false when the animation is finished.
+     * @see #dnaReplication(double, double, int, double, int, int, ParticleDisplay)
      * @since 3.0.0
      */
-    public static BukkitTask helix(Plugin plugin, int strings, double radius, double rate, double extension, int height, int speed,
+    public static BooleanSupplier helix(int strings, double radius, double rate, double extension, int height, int speed,
                                    boolean fadeUp, boolean fadeDown, ParticleDisplay display) {
-        return new BukkitRunnable() {
+        return new BooleanSupplier() {
             // If we look at a helix string from above, we'll see a circle tunnel.
             // To make this tunnel we're going to generate circles while moving
             // upwards to get a curvy tunnel.
@@ -1364,7 +1482,7 @@ public final class XParticle {
             double y = 0;
 
             @Override
-            public void run() {
+            public boolean getAsBoolean() {
                 int repeat = speed;
                 while (repeat-- > 0) {
                     y += rate;
@@ -1386,11 +1504,38 @@ public final class XParticle {
                         display.rotate(0, -angle, 0);
                         tempString--;
                     }
-
-                    if (y > height) cancel();
                 }
+                return y <= height;
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, 1L);
+        };
+    }
+
+    /**
+     * Spawns animated helix shapes.
+     *
+     * @param plugin    the timer handler.
+     * @param strings   the amount of helix strings. The rotation angle will split equally for each.
+     * @param radius    the radius of the helix.
+     * @param rate      the rate of helix points.
+     * @param extension the helix circle extension.
+     * @param height    the height of the helix.
+     * @param speed     the speed of the rate builder in each animation tick.
+     * @param fadeUp    helix radius will decrease to zero as it gets closer to the top.
+     * @param fadeDown  helix radius will increase to the original radius as it gets closer to the center.
+     *
+     * @return the animation task.
+     * @see #dnaReplication(Plugin, double, double, int, double, int, int, ParticleDisplay)
+     * @since 3.0.0
+     */
+    public static BukkitTask helix(Plugin plugin, int strings, double radius, double rate, double extension, int height, int speed,
+                                   boolean fadeUp, boolean fadeDown, ParticleDisplay display) {
+        BooleanSupplier helix = helix(strings, radius, rate, extension, height, speed, fadeUp, fadeDown, display);
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!helix.getAsBoolean()) cancel();
+            }
+        }.runTaskTimerAsynchronously(plugin, 0, 1);
     }
 
     /**
@@ -1502,7 +1647,6 @@ public final class XParticle {
     /**
      * Spawn an animated DNA replication with colored bonds.
      *
-     * @param plugin           the timer handler.
      * @param radius           the radius of DNA helix circle.
      * @param rate             the rate of DNA points.
      * @param speed            the number of points to build in a single tick. Recommended is 5.
@@ -1510,24 +1654,24 @@ public final class XParticle {
      * @param height           the height of the DNA strings.
      * @param hydrogenBondDist the distance between two DNA string helix points in a single string for each hydrogen bond to be formed.
      *
-     * @return the timer handling the animation.
+     * @return the runnable handling the animation. It will return false when the animation is finished.
      * @see #dna(double, double, double, int, int, ParticleDisplay, ParticleDisplay)
      * @since 3.0.0
      */
-    public static BukkitTask dnaReplication(Plugin plugin, double radius, double rate, int speed, double extension,
-                                            int height, int hydrogenBondDist, ParticleDisplay display) {
+    public static BooleanSupplier dnaReplication(double radius, double rate, int speed, double extension,
+                                                               int height, int hydrogenBondDist, ParticleDisplay display) {
         // We'll use the common nucleotide colors.
         ParticleDisplay adenine = ParticleDisplay.colored(null, java.awt.Color.BLUE, 1); // Blue
         ParticleDisplay thymine = ParticleDisplay.colored(null, java.awt.Color.YELLOW, 1); // Yellow
         ParticleDisplay guanine = ParticleDisplay.colored(null, java.awt.Color.GREEN, 1); // Green
         ParticleDisplay cytosine = ParticleDisplay.colored(null, java.awt.Color.RED, 1); // Red
 
-        return new BukkitRunnable() {
+        return new BooleanSupplier() {
             double y = 0;
             int nucleotideDist = 0;
 
             @Override
-            public void run() {
+            public boolean getAsBoolean() {
                 int repeat = speed;
                 while (repeat-- != 0) {
                     y += rate;
@@ -1563,11 +1707,38 @@ public final class XParticle {
                             line(nucleotide2, midPointBond, rate - 0.1, guanine);
                         }
                     }
+                }
+                return y < height;
+            }
+        };
+    }
 
-                    if (y >= height) cancel();
+    /**
+     * Spawn an animated DNA replication with colored bonds.
+     *
+     * @param plugin           the timer handler.
+     * @param radius           the radius of DNA helix circle.
+     * @param rate             the rate of DNA points.
+     * @param speed            the number of points to build in a single tick. Recommended is 5.
+     * @param extension        the extension of the DNA helix sin/cos waves.
+     * @param height           the height of the DNA strings.
+     * @param hydrogenBondDist the distance between two DNA string helix points in a single string for each hydrogen bond to be formed.
+     *
+     * @return the timer handling the animation.
+     * @see #dna(double, double, double, int, int, ParticleDisplay, ParticleDisplay)
+     * @since 3.0.0
+     */
+    public static BukkitTask dnaReplication(Plugin plugin, double radius, double rate, int speed, double extension,
+                                            int height, int hydrogenBondDist, ParticleDisplay display) {
+        BooleanSupplier dnaReplication = dnaReplication(radius, rate, speed, extension, height, hydrogenBondDist, display);
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!dnaReplication.getAsBoolean()) {
+                    cancel();
                 }
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, 1L);
+        }.runTaskTimerAsynchronously(plugin, 0, 1);
     }
 
     /**
@@ -1588,6 +1759,22 @@ public final class XParticle {
     /**
      * A simple method to spawn animated clouds effect.
      *
+     * @param cloud  recommended particle is {@link Particle#CLOUD} or {@link Particle#SMOKE_LARGE} and the offset xyz should be higher than 2
+     * @param rain   recommended particle is {@link Particle#WATER_DROP} or {@link Particle#FALLING_LAVA} and the offset xyz should be the same as cloud.
+     *
+     * @return the runnable handling the animation.
+     * @since 1.0.0
+     */
+    public static Runnable cloud(ParticleDisplay cloud, ParticleDisplay rain) {
+        return () -> {
+            cloud.spawn();
+            rain.spawn();
+        };
+    }
+
+    /**
+     * A simple method to spawn animated clouds effect.
+     *
      * @param plugin the timer handler.
      * @param cloud  recommended particle is {@link Particle#CLOUD} or {@link Particle#SMOKE_LARGE} and the offset xyz should be higher than 2
      * @param rain   recommended particle is {@link Particle#WATER_DROP} or {@link Particle#FALLING_LAVA} and the offset xyz should be the same as cloud.
@@ -1596,13 +1783,7 @@ public final class XParticle {
      * @since 1.0.0
      */
     public static BukkitTask cloud(Plugin plugin, ParticleDisplay cloud, ParticleDisplay rain) {
-        return new BukkitRunnable() {
-            @Override
-            public void run() {
-                cloud.spawn();
-                rain.spawn();
-            }
-        }.runTaskTimerAsynchronously(plugin, 0L, 1L);
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, cloud(cloud, rain), 0, 1);
     }
 
     /**
@@ -1908,16 +2089,17 @@ public final class XParticle {
      * https://en.wikipedia.org/wiki/Tesseract
      * https://en.wikipedia.org/wiki/Rotation_matrix
      *
-     * @param plugin the timer handler.
      * @param size   the size of the tesseract. Recommended is 4
      * @param rate   the rate of the tesseract points. Recommended is 0.3
      * @param speed  the speed of the tesseract matrix motion. Recommended is 0.01
      * @param ticks  the amount of ticks to keep the animation.
      *
+     * @return the animation runnable. It will return false when the animation is over.
+     *
      * @see #hypercube(Location, Location, double, double, int, ParticleDisplay)
      * @since 4.0.0
      */
-    public static BukkitTask tesseract(Plugin plugin, double size, double rate, double speed, long ticks, ParticleDisplay display) {
+    public static BooleanSupplier tesseract(double size, double rate, double speed, long ticks, ParticleDisplay display) {
         // We can multiply these later to change the size.
         // This array doesn't really need to be a constant as it's initialized once.
         double[][] positions = {
@@ -1967,12 +2149,12 @@ public final class XParticle {
         }
         for (int i = 0; i < (level + 1) * 4; i++) connections.add(new int[]{i, i + 8});
 
-        return new BukkitRunnable() {
+        return new BooleanSupplier() {
             double angle = 0;
             long repeat = 0;
 
             @Override
-            public void run() {
+            public boolean getAsBoolean() {
                 double cos = Math.cos(angle);
                 double sin = Math.sin(angle);
 
@@ -2024,10 +2206,42 @@ public final class XParticle {
                     line(start, end, rate, display);
                 }
 
-                if (++repeat > ticks) cancel();
-                else angle += speed;
+                if (++repeat > ticks) {
+                    return false;
+                } else {
+                    angle += speed;
+                    return true;
+                }
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, 1L);
+        };
+    }
+
+    /**
+     * Animated 4D tesseract using matrix motion.
+     * Since this is a 4D shape the usage should be highly limited.
+     * A failed prototype: https://imgur.com/eziNk7x
+     * Final Version: https://imgur.com/Vb2HDQN
+     * <p>
+     * https://en.wikipedia.org/wiki/Tesseract
+     * https://en.wikipedia.org/wiki/Rotation_matrix
+     *
+     * @param plugin the timer handler.
+     * @param size   the size of the tesseract. Recommended is 4
+     * @param rate   the rate of the tesseract points. Recommended is 0.3
+     * @param speed  the speed of the tesseract matrix motion. Recommended is 0.01
+     * @param ticks  the amount of ticks to keep the animation.
+     *
+     * @see #hypercube(Location, Location, double, double, int, ParticleDisplay)
+     * @since 4.0.0
+     */
+    public static BukkitTask tesseract(Plugin plugin, double size, double rate, double speed, long ticks, ParticleDisplay display) {
+        BooleanSupplier tesseract = tesseract(size, rate, speed, ticks, display);
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!tesseract.getAsBoolean()) cancel();
+            }
+        }.runTaskTimerAsynchronously(plugin, 0, 1);
     }
 
     /**
@@ -2146,7 +2360,6 @@ public final class XParticle {
      * Note that the animation is intended to be used with prototype mode enabled.
      * Animations without prototype doesn't really look good. You might want to increase the speed.
      *
-     * @param plugin      the timer handler.
      * @param points      the number of circle sides with spikes.
      * @param spikes      the number of spikes on each side.
      * @param rate        the rate of star points.
@@ -2158,24 +2371,27 @@ public final class XParticle {
      * @param prototype   if the spikes of the star should use helix instead of a random generator.
      * @param speed       the speed of animation. Smoothest/slowest is 1
      *
+     * @return a list of runnables. They will return false when the animation is done.
+     *
      * @see #spikeSphere(double, double, int, double, double, ParticleDisplay)
      * @since 3.0.0
      */
-    public static void star(Plugin plugin, int points, int spikes, double rate, double spikeLength, double coreRadius,
+    public static List<BooleanSupplier> star(int points, int spikes, double rate, double spikeLength, double coreRadius,
                             double neuron, boolean prototype, int speed, ParticleDisplay display) {
         double pointsRate = PII / points;
         double rateDiv = Math.PI / rate;
         ThreadLocalRandom random = prototype ? null : ThreadLocalRandom.current();
+        List<BooleanSupplier> tasks = new ArrayList<>();
 
         for (int i = 0; i < spikes * 2; i++) {
             double spikeAngle = i * Math.PI / spikes;
 
-            new BukkitRunnable() {
+            tasks.add(new BooleanSupplier() {
                 double vein = 0;
                 double theta = 0;
 
                 @Override
-                public void run() {
+                public boolean getAsBoolean() {
                     int repeat = speed;
                     while (repeat-- != 0) {
                         theta += rateDiv;
@@ -2197,12 +2413,47 @@ public final class XParticle {
                             ParticleDisplay.rotateAround(vector, ParticleDisplay.Axis.Y, pointsRate);
                             display.spawn(vector);
                         }
-
-                        if (theta >= PII) cancel();
                     }
+
+                    return theta < PII;
                 }
-            }.runTaskTimerAsynchronously(plugin, 0L, 1L);
+            });
         }
+        return tasks;
+    }
+
+    /**
+     * Spawn 3D spiked circles.
+     * Note that the animation is intended to be used with prototype mode enabled.
+     * Animations without prototype doesn't really look good. You might want to increase the speed.
+     *
+     * @param plugin      the timer handler.
+     * @param points      the number of circle sides with spikes.
+     * @param spikes      the number of spikes on each side.
+     * @param rate        the rate of star points.
+     * @param spikeLength the length of each spike.
+     * @param coreRadius  the radius of the center circle.
+     * @param neuron      the neuron level. Neuron level is affected by the prototype mode.
+     *                    Normal value is 1 if prototype mode is disabled. If the value goes higher than 1 it'll form a neuron-like body cell shape.
+     *                    The value is used in small ranges for when prototype mode is enabled. Usually between 0.01 and 0.1
+     * @param prototype   if the spikes of the star should use helix instead of a random generator.
+     * @param speed       the speed of animation. Smoothest/slowest is 1
+     *
+     * @see #spikeSphere(double, double, int, double, double, ParticleDisplay)
+     * @since 3.0.0
+     */
+    public static List<BukkitTask> star(Plugin plugin, int points, int spikes, double rate, double spikeLength, double coreRadius,
+                            double neuron, boolean prototype, int speed, ParticleDisplay display) {
+        List<BukkitTask> tasks = new ArrayList<>();
+        for (BooleanSupplier task : star(points, spikes, rate, spikeLength, coreRadius, neuron, prototype, speed, display)) {
+            tasks.add(new BukkitRunnable() {
+                @Override
+                public void run() {
+                    if (!task.getAsBoolean()) cancel();
+                }
+            }.runTaskTimerAsynchronously(plugin, 0, 1));
+        }
+        return tasks;
     }
 
     /**
@@ -2330,11 +2581,45 @@ public final class XParticle {
      * @see #circle(double, double, ParticleDisplay)
      * @since 1.0.0
      */
-    public static void meguminExplosion(Plugin plugin, double size, ParticleDisplay display) {
-        polygon(10, 4, size, 0.02, 0.3, display);
-        polygon(10, 3, size / (size - 1), 0.5, 0, display);
-        circle(size, 40, display);
-        spread(plugin, 30, 2, display.getLocation(), display.getLocation().clone().add(0, 10, 0), 5, 5, 5, display);
+    public static BooleanSupplier meguminExplosion(double size, ParticleDisplay display) {
+        BooleanSupplier spread = spread(30, 2, display.getLocation(), display.getLocation().clone().add(0, 10, 0), 5, 5, 5, display);
+        return new BooleanSupplier() {
+            boolean first = true;
+
+            @Override
+            public boolean getAsBoolean() {
+                if (first) {
+                    first = false;
+                    polygon(10, 4, size, 0.02, 0.3, display);
+                    polygon(10, 3, size / (size - 1), 0.5, 0, display);
+                    circle(size, 40, display);
+                }
+                return spread.getAsBoolean();
+            }
+        };
+    }
+
+    /**
+     * This is supposed to be something similar to this: https://www.deviantart.com/pwincessstar/art/701840646
+     * The numbers on this shape are really sensitive. Changing a single one can result
+     * in a totally different shape.
+     *
+     * @param size the shape of the explosion circle. Recommended value is 6
+     *
+     * @see #polygon(int, int, double, double, double, ParticleDisplay)
+     * @see #circle(double, double, ParticleDisplay)
+     * @since 1.0.0
+     */
+    public static BukkitTask meguminExplosion(Plugin plugin, double size, ParticleDisplay display) {
+        BooleanSupplier explosion = meguminExplosion(size, display);
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!explosion.getAsBoolean()) {
+                    cancel();
+                }
+            }
+        }.runTaskTimerAsynchronously(plugin, 0, 1);
     }
 
     /**
@@ -2343,15 +2628,18 @@ public final class XParticle {
      *
      * @param rate the distance between each cos/sin lines.
      *
+     * @return the animation runnable. It will return false when it's done.
+     *
      * @since 1.0.0
      */
-    public static BukkitTask explosionWave(Plugin plugin, double rate, ParticleDisplay display, ParticleDisplay secDisplay) {
-        return new BukkitRunnable() {
+    public static BooleanSupplier explosionWave(double rate, ParticleDisplay display, ParticleDisplay secDisplay) {
+        return new BooleanSupplier() {
             final double addition = Math.PI * 0.1;
             final double rateDiv = Math.PI / rate;
             double times = Math.PI / 4;
 
-            public void run() {
+            @Override
+            public boolean getAsBoolean() {
                 times += addition;
                 for (double theta = 0; theta <= PII; theta += rateDiv) {
                     double x = times * Math.cos(theta);
@@ -2365,10 +2653,27 @@ public final class XParticle {
                     z = times * Math.sin(theta);
                     secDisplay.spawn(x, y, z);
                 }
-
-                if (times > 20) cancel();
+                return times <= 20;
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, 1L);
+        };
+    }
+
+    /**
+     * A sin/cos based smoothly animated explosion wave.
+     * Source: https://www.youtube.com/watch?v=n8W7RxW5KB4
+     *
+     * @param rate the distance between each cos/sin lines.
+     *
+     * @since 1.0.0
+     */
+    public static BukkitTask explosionWave(Plugin plugin, double rate, ParticleDisplay display, ParticleDisplay secDisplay) {
+        BooleanSupplier explosionWave = explosionWave(rate, display, secDisplay);
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!explosionWave.getAsBoolean()) cancel();
+            }
+        }.runTaskTimerAsynchronously(plugin, 0, 1);
     }
 
     /**
@@ -2491,6 +2796,36 @@ public final class XParticle {
     /**
      * Display a rendered image repeatedly.
      *
+     * @param render   the rendered image map.
+     * @param location the dynamic location to display the image at.
+     * @param repeat   amount of times to repeat displaying the image.
+     * @param quality  the quality of the image is exactly the number of particles display for each pixel. Recommended value is 1
+     * @param speed    the speed is exactly the same value as the speed of particles. Recommended amount is 0
+     * @param size     the size of the particle. Recommended amount is 0.8
+     *
+     * @return the async bukkit task displaying the image.
+     * @since 1.0.0
+     */
+    public static BooleanSupplier displayRenderedImage(Map<double[], Color> render, Callable<Location> location,
+                                                  int repeat, int quality, int speed, float size) {
+        return new BooleanSupplier() {
+            int times = repeat;
+
+            @Override
+            public boolean getAsBoolean() {
+                try {
+                    displayRenderedImage(render, location.call(), quality, speed, size);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                return times-- > 0;
+            }
+        };
+    }
+
+    /**
+     * Display a rendered image repeatedly.
+     *
      * @param plugin   the scheduler handler.
      * @param render   the rendered image map.
      * @param location the dynamic location to display the image at.
@@ -2505,19 +2840,13 @@ public final class XParticle {
      */
     public static BukkitTask displayRenderedImage(Plugin plugin, Map<double[], Color> render, Callable<Location> location,
                                                   int repeat, long period, int quality, int speed, float size) {
+        BooleanSupplier displayRenderedImage = displayRenderedImage(render, location, repeat, quality, speed, size);
         return new BukkitRunnable() {
-            int times = repeat;
-
             @Override
             public void run() {
-                try {
-                    displayRenderedImage(render, location.call(), quality, speed, size);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-                if (times-- < 1) cancel();
+                if (!displayRenderedImage.getAsBoolean()) cancel();
             }
-        }.runTaskTimerAsynchronously(plugin, 0L, period);
+        }.runTaskTimerAsynchronously(plugin, 0, period);
     }
 
     /**


### PR DESCRIPTION
This attempts to split all logic from particle tasks to be Runnable & BooleanSupplier, so that it can be used in other ways of scheduling tasks, like those new Folia's schedulers ([BukkitScheduler's deprecation note](https://jd.papermc.io/folia/1.19/org/bukkit/scheduler/BukkitScheduler.html)).