### PR TITLE
XTag - INVENTORY_NOT_DISPLAYABLE improvements 

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XTag.java
+++ b/src/main/java/com/cryptomorin/xseries/XTag.java
@@ -2283,13 +2283,15 @@ public final class XTag<T extends Enum<T>> {
         FIRE = new XTag<>(XMaterial.FIRE, XMaterial.SOUL_FIRE);
         FLUID = new XTag<>(XMaterial.LAVA, XMaterial.WATER);
 
-        INVENTORY_NOT_DISPLAYABLE = new XTag<>(XMaterial.class, AIR, CAVE_VINES, FILLED_CAULDRONS, FIRE, FLUID, PORTALS, WALL_SIGNS, WALL_HANGING_SIGNS,
-                WALL_TORCHES, ALIVE_CORAL_WALL_FANS, DEAD_CORAL_WALL_FANS, WALL_HEADS, CANDLE_CAKES, WALL_BANNERS, FLOWER_POTS.without(XMaterial.FLOWER_POT),
-                CROPS.without(XMaterial.WHEAT), new XTag<>(XMaterial.BIG_DRIPLEAF_STEM, XMaterial.SWEET_BERRY_BUSH, XMaterial.KELP_PLANT,
-                XMaterial.FROSTED_ICE, XMaterial.ATTACHED_MELON_STEM, XMaterial.ATTACHED_PUMPKIN_STEM, XMaterial.COCOA,
-                XMaterial.MOVING_PISTON, XMaterial.PISTON_HEAD, XMaterial.PITCHER_CROP, XMaterial.POWDER_SNOW,
-                XMaterial.REDSTONE_WIRE, XMaterial.TALL_SEAGRASS, XMaterial.TRIPWIRE, XMaterial.TORCHFLOWER_CROP,
-                XMaterial.BUBBLE_COLUMN, XMaterial.TWISTING_VINES_PLANT, XMaterial.WEEPING_VINES_PLANT, XMaterial.BAMBOO_SAPLING));
+        INVENTORY_NOT_DISPLAYABLE = new XTag<>(XMaterial.class, AIR, CAVE_VINES, FILLED_CAULDRONS, FIRE, FLUID, PORTALS,
+                WALL_SIGNS, WALL_HANGING_SIGNS, WALL_TORCHES, ALIVE_CORAL_WALL_FANS, DEAD_CORAL_WALL_FANS, WALL_HEADS,
+                CANDLE_CAKES, WALL_BANNERS, FLOWER_POTS.without(XMaterial.FLOWER_POT), CROPS.without(XMaterial.WHEAT),
+                new XTag<>(XMaterial.BIG_DRIPLEAF_STEM, XMaterial.SWEET_BERRY_BUSH, XMaterial.KELP_PLANT,
+                        XMaterial.FROSTED_ICE, XMaterial.ATTACHED_MELON_STEM, XMaterial.ATTACHED_PUMPKIN_STEM,
+                        XMaterial.COCOA, XMaterial.MOVING_PISTON, XMaterial.PISTON_HEAD, XMaterial.PITCHER_CROP,
+                        XMaterial.POWDER_SNOW, XMaterial.REDSTONE_WIRE, XMaterial.TALL_SEAGRASS, XMaterial.TRIPWIRE,
+                        XMaterial.TORCHFLOWER_CROP, XMaterial.BUBBLE_COLUMN, XMaterial.TWISTING_VINES_PLANT,
+                        XMaterial.WEEPING_VINES_PLANT, XMaterial.BAMBOO_SAPLING));
     }
 
     @Nonnull

--- a/src/main/java/com/cryptomorin/xseries/XTag.java
+++ b/src/main/java/com/cryptomorin/xseries/XTag.java
@@ -26,6 +26,7 @@ import org.bukkit.Material;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public final class XTag<T extends Enum<T>> {
 
@@ -2282,10 +2283,13 @@ public final class XTag<T extends Enum<T>> {
         FIRE = new XTag<>(XMaterial.FIRE, XMaterial.SOUL_FIRE);
         FLUID = new XTag<>(XMaterial.LAVA, XMaterial.WATER);
 
-        INVENTORY_NOT_DISPLAYABLE = new XTag<>(XMaterial.class, AIR, FIRE, FLUID, PORTALS, WALL_SIGNS,
-                CORAL_FANS, WALL_HEADS, CANDLE_CAKES, WALL_BANNERS, FLOWER_POTS,
-                new XTag<>(XMaterial.SWEET_BERRY_BUSH, XMaterial.CHORUS_PLANT, XMaterial.KELP_PLANT,
-                        XMaterial.CAVE_VINES_PLANT, XMaterial.TWISTING_VINES_PLANT, XMaterial.WEEPING_VINES_PLANT));
+        INVENTORY_NOT_DISPLAYABLE = new XTag<>(XMaterial.class, AIR, CAVE_VINES, FILLED_CAULDRONS, FIRE, FLUID, PORTALS, WALL_SIGNS, WALL_HANGING_SIGNS,
+                WALL_TORCHES, ALIVE_CORAL_WALL_FANS, DEAD_CORAL_WALL_FANS, WALL_HEADS, CANDLE_CAKES, WALL_BANNERS, FLOWER_POTS.without(XMaterial.FLOWER_POT),
+                CROPS.without(XMaterial.WHEAT), new XTag<>(XMaterial.BIG_DRIPLEAF_STEM, XMaterial.SWEET_BERRY_BUSH, XMaterial.KELP_PLANT,
+                XMaterial.FROSTED_ICE, XMaterial.ATTACHED_MELON_STEM, XMaterial.ATTACHED_PUMPKIN_STEM, XMaterial.COCOA,
+                XMaterial.MOVING_PISTON, XMaterial.PISTON_HEAD, XMaterial.PITCHER_CROP, XMaterial.POWDER_SNOW,
+                XMaterial.REDSTONE_WIRE, XMaterial.TALL_SEAGRASS, XMaterial.TRIPWIRE, XMaterial.TORCHFLOWER_CROP,
+                XMaterial.BUBBLE_COLUMN, XMaterial.TWISTING_VINES_PLANT, XMaterial.WEEPING_VINES_PLANT, XMaterial.BAMBOO_SAPLING));
     }
 
     @Nonnull
@@ -2300,6 +2304,10 @@ public final class XTag<T extends Enum<T>> {
     private XTag(@Nonnull Class<T> clazz, @Nonnull XTag<T>... values) {
         this.values = EnumSet.noneOf(clazz);
         this.inheritFrom(values);
+    }
+
+    private XTag(@Nonnull Set<T> values) {
+        this.values = Collections.unmodifiableSet(values);
     }
 
     private static XMaterial[] findAllColors(String material) {
@@ -2625,6 +2633,14 @@ public final class XTag<T extends Enum<T>> {
 
     public boolean isTagged(@Nullable T value) {
         return value != null && this.values.contains(value);
+    }
+
+    @SafeVarargs
+    private final XTag<T> without(T... without) {
+        Set<T> ignore = new HashSet<>();
+        Collections.addAll(ignore, without);
+        Set<T> newValues = values.stream().filter(t -> !ignore.contains(t)).collect(Collectors.toSet());
+        return new XTag<>(newValues);
     }
 
     @SafeVarargs

--- a/src/main/java/com/cryptomorin/xseries/XTag.java
+++ b/src/main/java/com/cryptomorin/xseries/XTag.java
@@ -315,6 +315,11 @@ public final class XTag<T extends Enum<T>> {
     @Nonnull
     public static final XTag<XMaterial> FENCES;
     /**
+     * Tag representing all possible variants of filled cauldron
+     */
+    @Nonnull
+    public static final XTag<XMaterial> FILLED_CAULDRONS;
+    /**
      * Tag representing all possible variants fire
      */
     @Nonnull
@@ -792,6 +797,11 @@ public final class XTag<T extends Enum<T>> {
     @Nonnull
     public static final XTag<XMaterial> VALID_SPAWN;
     /**
+     * Tag representing all possible variants of wall hanging sign
+     */
+    @Nonnull
+    public static final XTag<XMaterial> WALL_HANGING_SIGNS;
+    /**
      * Tag representing all possible block types that can override a wall post creation
      */
     @Nonnull
@@ -801,6 +811,11 @@ public final class XTag<T extends Enum<T>> {
      */
     @Nonnull
     public static final XTag<XMaterial> WALL_SIGNS;
+    /**
+     * Tag representing all possible types of wall torches
+     */
+    @Nonnull
+    public static final XTag<XMaterial> WALL_TORCHES;
     /**
      * Tag representing all different types of walls
      */
@@ -1070,6 +1085,7 @@ public final class XTag<T extends Enum<T>> {
     static { // wooded material
         STANDING_SIGNS = new XTag<>(findAllWoodTypes("SIGN"));
         WALL_SIGNS = new XTag<>(findAllWoodTypes("WALL_SIGN"));
+        WALL_HANGING_SIGNS = new XTag<>(findAllWoodTypes("WALL_HANGING_SIGN"));
         HANGING_SIGNS = new XTag<>(findAllWoodTypes("HANGING_SIGN"));
         WOODEN_PRESSURE_PLATES = new XTag<>(findAllWoodTypes("PRESSURE_PLATE"));
         WOODEN_DOORS = new XTag<>(findAllWoodTypes("DOOR"));
@@ -1127,6 +1143,9 @@ public final class XTag<T extends Enum<T>> {
         WALL_HEADS = new XTag<>(XMaterial.class, new XTag<>(findMaterialsEndingWith("WALL_HEAD")),
                 new XTag<>(XMaterial.WITHER_SKELETON_WALL_SKULL, XMaterial.SKELETON_WALL_SKULL));
 
+        WALL_TORCHES = new XTag<>(XMaterial.WALL_TORCH,
+                XMaterial.SOUL_WALL_TORCH,
+                XMaterial.REDSTONE_WALL_TORCH);
         WALLS = new XTag<>(XMaterial.POLISHED_DEEPSLATE_WALL,
                 XMaterial.NETHER_BRICK_WALL,
                 XMaterial.POLISHED_BLACKSTONE_WALL,
@@ -1197,6 +1216,9 @@ public final class XTag<T extends Enum<T>> {
                 XMaterial.PUMPKIN_STEM);
         CAMPFIRES = new XTag<>(XMaterial.CAMPFIRE,
                 XMaterial.SOUL_CAMPFIRE);
+        FILLED_CAULDRONS = new XTag<>(XMaterial.LAVA_CAULDRON,
+                XMaterial.POWDER_SNOW_CAULDRON,
+                XMaterial.WATER_CAULDRON);
         CAULDRONS = new XTag<>(XMaterial.CAULDRON,
                 XMaterial.LAVA_CAULDRON,
                 XMaterial.POWDER_SNOW_CAULDRON,

--- a/src/main/java/com/cryptomorin/xseries/XTag.java
+++ b/src/main/java/com/cryptomorin/xseries/XTag.java
@@ -1327,7 +1327,8 @@ public final class XTag<T extends Enum<T>> {
                 XMaterial.POTTED_JUNGLE_SAPLING,
                 XMaterial.POTTED_BIRCH_SAPLING,
                 XMaterial.POTTED_MANGROVE_PROPAGULE,
-                XMaterial.POTTED_CHERRY_SAPLING);
+                XMaterial.POTTED_CHERRY_SAPLING,
+                XMaterial.POTTED_TORCHFLOWER);
         FOX_FOOD = new XTag<>(XMaterial.GLOW_BERRIES,
                 XMaterial.SWEET_BERRIES);
         FOXES_SPAWNABLE_ON = new XTag<>(XMaterial.SNOW,


### PR DESCRIPTION
## **Issue**
`INVENTORY_NOT_DISPLAYABLE` contained some materials that could be displayed and some materials that could not be displayed.

## **Changes (Description)**.
Along with the improvements to `INVENTORY_NOT_DISPLAYABLE`, I added `XMaterial.POTTED_TORCHFLOWER` to `FLOWER_POTS`, as well as three new tags (`WALL_TORCHES`, `FILLED_CAULDRONS` and `WALL_HANGING_SIGNS`) - all materials in these three tags cannot be displayed in an inventory. Also, I added `XTag#without(T...)` - this method returns a new XTag with all items that were included in the old one, except those specified as arguments. I'm not sure if this method could be useful outside the XTag class - but maybe it is and the method should be public instead?

For the changes regarding `INVENTORY_NOT_DISPLAYABLE` :
- I removed `XMaterial.CHORUS_PLANT` as it can be displayed in the inventory (tested in MC 1.20.1 and 1.9.4).
- replaced `CORAL_FANS` with `ALIVE_CORAL_WALL_FANS` and `DEAD_CORAL_WALL_FANS`, because `ALIVE_CORAL_FANS` and `DEAD_CORAL_FANS` can be displayed
- `FLOWER_POTS` has been replaced by `FLOWER_POTS.without(XMaterial.FLOWER_POT)` - this solves the problem that the flowerpot is tagged as not displayable, everything else in `FLOWER_POTS` remains tagged
- replaced `XMaterial.CAVE_VINES_PLANT` with `CAVE_VINES` because both `XMaterial.CAVE_VINES_PLANT` and `XMaterial.CAVE_VINES` are not displayable in the inventory
- I have added `FILLED_CAULLDRONS` to `INVENTORY_NOT_DISPLAYABLE` - this could also be replaced by `CAULDRONS.without(XMaterial.CAULDRON)`, however `FILLED_CAULLDRONS` could be a useful tag
- `CROPS.without(XMaterial.WHEAT)` was also added - all crops except `XMaterial.WHEAT` are not displayable. An exception is `XMaterials.BEETROOTS`, which are displayed in some versions (tested in MC 1.9.4). But since they are not displayed in 1.20.1 and also `XMaterials.BEETROOT` still exists, I decided to also add `XMaterials.BEETROOTS` as not displayable.
- Some other values that were missing are: `WALL_TORCHES`, `WALL_HANGING_SINGS`, `XMaterials.BIG_DRIPLEAF_STEM`, `XMaterials.FROSTED_ICE`, `XMaterials.ATTACHED_MELON_STEM`, `XMaterials.ATTACHED_PUMPKIN_STEM`, `XMaterial.COCOA`, `XMaterial.MOVING_PISTON`, `XMaterial.PISTON_HEAD`, `XMaterial.PITCHER_CROP`, `XMaterial.POWDER_SNOW`, `XMaterial.REDSTONE_WIRE`, `XMaterial.TALL_SEAGRASS`, `XMaterial.TRIPWIRE`, `XMaterial.TORCHFLOWER_CROP`, `XMaterial.BUBBLE_COLUMN`, `XMaterial.BAMBOO_SAPLING`
  
With these changes, `INVENTORY_NOT_DISPLAYABLE` should only indicate materials that are not displayable.