### PR TITLE
Error with equipment drop chance with armor stands

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XEntity.java
+++ b/src/main/java/com/cryptomorin/xseries/XEntity.java
@@ -206,41 +206,54 @@ public final class XEntity {
             ConfigurationSection equip = config.getConfigurationSection("equipment");
             if (equip != null) {
                 EntityEquipment equipment = living.getEquipment();
+                boolean isMob = entity instanceof Mob;
 
                 ConfigurationSection helmet = equip.getConfigurationSection("helmet");
                 if (helmet != null) {
                     equipment.setHelmet(XItemStack.deserialize(helmet.getConfigurationSection("item")));
-                    equipment.setHelmetDropChance(helmet.getInt("drop-chance"));
+                    if (isMob) {
+                        equipment.setHelmetDropChance(helmet.getInt("drop-chance"));
+                    }
                 }
 
                 ConfigurationSection chestplate = equip.getConfigurationSection("chestplate");
                 if (chestplate != null) {
                     equipment.setChestplate(XItemStack.deserialize(chestplate.getConfigurationSection("item")));
-                    equipment.setChestplateDropChance(chestplate.getInt("drop-chance"));
+                    if (isMob) {
+                        equipment.setChestplateDropChance(chestplate.getInt("drop-chance"));
+                    }
                 }
 
                 ConfigurationSection leggings = equip.getConfigurationSection("leggings");
                 if (leggings != null) {
                     equipment.setLeggings(XItemStack.deserialize(leggings.getConfigurationSection("item")));
-                    equipment.setLeggingsDropChance(leggings.getInt("drop-chance"));
+                    if (isMob) {
+                        equipment.setLeggingsDropChance(leggings.getInt("drop-chance"));
+                    }
                 }
 
                 ConfigurationSection boots = equip.getConfigurationSection("boots");
                 if (boots != null) {
                     equipment.setBoots(XItemStack.deserialize(boots.getConfigurationSection("item")));
-                    equipment.setBootsDropChance(boots.getInt("drop-chance"));
+                    if (isMob) {
+                        equipment.setBootsDropChance(boots.getInt("drop-chance"));
+                    }
                 }
 
                 ConfigurationSection mainHand = equip.getConfigurationSection("main-hand");
                 if (mainHand != null) {
                     equipment.setItemInMainHand(XItemStack.deserialize(mainHand.getConfigurationSection("item")));
-                    equipment.setItemInMainHandDropChance(mainHand.getInt("drop-chance"));
+                    if (isMob) {
+                        equipment.setItemInMainHandDropChance(mainHand.getInt("drop-chance"));
+                    }
                 }
 
                 ConfigurationSection offHand = equip.getConfigurationSection("off-hand");
                 if (offHand != null) {
                     equipment.setItemInOffHand(XItemStack.deserialize(offHand.getConfigurationSection("item")));
-                    equipment.setItemInOffHandDropChance(offHand.getInt("drop-chance"));
+                    if (isMob) {
+                        equipment.setItemInOffHandDropChance(offHand.getInt("drop-chance"));
+                    }
                 }
             }
 


### PR DESCRIPTION
Whenever loading an Armor Stand entity with equipment, throws an error. By checking if the entity is a Mob instance prevents this error being thrown.

```log
java.lang.IllegalArgumentException: Cannot set drop chance for non-Mob entity
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145) ~[guava-31.1-jre.jar:?]
	at org.bukkit.craftbukkit.v1_20_R1.inventory.CraftEntityEquipment.setDropChance(CraftEntityEquipment.java:260) ~[paper-1.20.1.jar:git-Paper-169]
	at org.bukkit.craftbukkit.v1_20_R1.inventory.CraftEntityEquipment.setHelmetDropChance(CraftEntityEquipment.java:215) ~[paper-1.20.1.jar:git-Paper-169]
	at com.cryptomorin.xseries.XEntity.edit(XEntity.java:213) ~[SnapSkyBlock-2.0.0-SNAPSHOT.jar:?]
	at com.cryptomorin.xseries.XEntity.spawn(XEntity.java:121) ~[SnapSkyBlock-2.0.0-SNAPSHOT.jar:?]
```

Used yaml to deserialize entity:
```yaml
entity:
  type: ARMOR_STAND
  gravity: false
  equipment:
    helmet:
      item:
        material: LEATHER_HELMET
    chestplate:
      item:
        material: LEATHER_CHESTPLATE
    leggings:
      item:
        material: LEATHER_LEGGINGS
    boots:
      item:
        material: LEATHER_BOOTS```