### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/NMSExtras.java
+++ b/src/main/java/com/cryptomorin/xseries/NMSExtras.java
@@ -286,7 +286,7 @@ public final class NMSExtras {
     }
 
     /**
-     * https://minecraft.gamepedia.com/Damage#Lightning_damage
+     * https://minecraft.wiki/w/Damage#Lightning_damage
      * Lightnings deal 5 damage.
      *
      * @param players  the players to send the packet to.

--- a/src/main/java/com/cryptomorin/xseries/NoteBlockMusic.java
+++ b/src/main/java/com/cryptomorin/xseries/NoteBlockMusic.java
@@ -40,7 +40,7 @@ import java.util.function.Supplier;
 
 /**
  * <b>NoteBlockMusic</b> - Write music scripts for Minecraft.<br>
- * You can write small text scripts for Minecraft <a href="https://minecraft.gamepedia.com/Note_Block">note blocks</a>
+ * You can write small text scripts for Minecraft <a href="https://minecraft.wiki/w/Note_Block">note blocks</a>
  * without needing to use any redstone or building to make your music.
  * This class is independent of XSound.
  *
@@ -126,7 +126,7 @@ public final class NoteBlockMusic {
      * The character paseed to this method is assumed to be uppercase,
      * otherwise it needs to be {@code ch & 0x5f} manually.
      * <p>
-     * https://minecraft.gamepedia.com/Note_Block#Notes
+     * https://minecraft.wiki/w/Note_Block#Notes
      *
      * @param ch the character of the note tone.
      * @return the note tone or null if not found.

--- a/src/main/java/com/cryptomorin/xseries/ReflectionUtils.java
+++ b/src/main/java/com/cryptomorin/xseries/ReflectionUtils.java
@@ -170,7 +170,7 @@ public final class ReflectionUtils {
     public static Integer getLatestPatchNumberOf(int minorVersion) {
         if (minorVersion <= 0) throw new IllegalArgumentException("Minor version must be positive: " + minorVersion);
 
-        // https://minecraft.fandom.com/wiki/Java_Edition_version_history
+        // https://minecraft.wiki/w/Java_Edition_version_history
         // There are many ways to do this, but this is more visually appealing.
         int[] patches = {
                 /* 1 */ 1,

--- a/src/main/java/com/cryptomorin/xseries/XBiome.java
+++ b/src/main/java/com/cryptomorin/xseries/XBiome.java
@@ -38,11 +38,11 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * <b>XBiome</b> - Cross-version support for biome names.<br>
- * Biomes: https://minecraft.gamepedia.com/Biome
+ * Biomes: https://minecraft.wiki/w/Biome
  * Biome: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/Biome.html
  * <p>
  * The ordering of this enum class matters and should not be changed due to
- * <a href="https://minecraft.fandom.com/wiki/Java_Edition_1.18">1.18 removed biomes issue.</a>
+ * <a href="https://minecraft.wiki/w/Java_Edition_1.18">1.18 removed biomes issue.</a>
  *
  * @author Crypto Morin
  * @version 6.1.1

--- a/src/main/java/com/cryptomorin/xseries/XEnchantment.java
+++ b/src/main/java/com/cryptomorin/xseries/XEnchantment.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  * <p>
  * EssentialsX Enchantment: https://github.com/Bukkit/Bukkit/blob/master/src/main/java/org/bukkit/enchantments/Enchantment.java
  * Enchantment: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/enchantments/Enchantment.html
- * Enchanting: https://minecraft.gamepedia.com/Enchanting
+ * Enchanting: https://minecraft.wiki/w/Enchanting
  *
  * @author Crypto Morin
  * @version 2.3.0

--- a/src/main/java/com/cryptomorin/xseries/XEntity.java
+++ b/src/main/java/com/cryptomorin/xseries/XEntity.java
@@ -61,7 +61,7 @@ import java.util.*;
  */
 public final class XEntity {
     /**
-     * A list of entity types that are considered <a href="https://minecraft.gamepedia.com/Undead">undead</a>.
+     * A list of entity types that are considered <a href="https://minecraft.wiki/w/Undead">undead</a>.
      *
      * @since 2.0.0
      */
@@ -99,7 +99,7 @@ public final class XEntity {
     }
 
     /**
-     * Checks if an entity is an <a href="https://minecraft.gamepedia.com/Undead">undead</a>.
+     * Checks if an entity is an <a href="https://minecraft.wiki/w/Undead">undead</a>.
      *
      * @param type the entity type.
      * @return true if the entity is an undead.

--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -152,7 +152,7 @@ public final class XItemStack {
             config.set("flags", flagNames);
         }
 
-        // Attributes - https://minecraft.gamepedia.com/Attribute
+        // Attributes - https://minecraft.wiki/w/Attribute
         if (supports(13)) {
             Multimap<Attribute, AttributeModifier> attributes = meta.getAttributeModifiers();
             if (attributes != null) {
@@ -938,7 +938,7 @@ public final class XItemStack {
                 meta.addItemFlags(ITEM_FLAGS);
         }
 
-        // Atrributes - https://minecraft.gamepedia.com/Attribute
+        // Atrributes - https://minecraft.wiki/w/Attribute
         if (supports(13)) {
             ConfigurationSection attributes = config.getConfigurationSection("attributes");
             if (attributes != null) {

--- a/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  * This class is mainly designed to support {@link ItemStack}. If you want to use it on blocks, you'll have to use
  * <a href="https://github.com/CryptoMorin/XSeries/blob/master/src/main/java/com/cryptomorin/xseries/XBlock.java">XBlock</a>
  * <p>
- * Pre-flattening: https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening
+ * Pre-flattening: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
  * Materials: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html
  * Materials (1.12): https://helpch.at/docs/1.12.2/index.html?org/bukkit/Material.html
  * Material IDs: https://minecraft-ids.grahamedgecombe.com/
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
  * <p>
  * This class will throw an "unsupported material" error if someone tries to use an item with an invalid data value which can only happen in 1.12 servers and below or when the
  * utility is missing a new material in that specific version.
- * To get an invalid item, (aka <a href="https://minecraft.fandom.com/wiki/Missing_Texture_Block">Missing Texture Block</a>) you can use the command
+ * To get an invalid item, (aka <a href="https://minecraft.wiki/w/Missing_Texture_Block">Missing Texture Block</a>) you can use the command
  * <b>/give @p minecraft:dirt 1 10</b> where 1 is the item amount, and 10 is the data value. The material {@link #DIRT} with a data value of {@code 10} doesn't exist.
  *
  * @author Crypto Morin
@@ -87,7 +87,7 @@ public enum XMaterial {
     ACACIA_WOOD(0, "LOG_2"),
     ACTIVATOR_RAIL,
     /**
-     * <a href="https://minecraft.gamepedia.com/Air">Air</a>
+     * <a href="https://minecraft.wiki/w/Air">Air</a>
      * {@link Material#isAir()}
      *
      * @see #VOID_AIR
@@ -966,7 +966,7 @@ public enum XMaterial {
     NETHER_SPROUTS,
     NETHER_STAR,
     /**
-     * Just like mentioned in <a href="https://minecraft.gamepedia.com/Nether_Wart">Nether Wart</a>
+     * Just like mentioned in <a href="https://minecraft.wiki/w/Nether_Wart">Nether Wart</a>
      * Nether wart is also known as nether stalk in the code.
      * NETHER_STALK is the planted state of nether warts.
      */
@@ -1665,7 +1665,7 @@ public enum XMaterial {
     }
 
     /**
-     * The data value of this material <a href="https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening">Pre-flattening</a>
+     * The data value of this material <a href="https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening">Pre-flattening</a>
      * It's never a negative number.
      *
      * @see #getData()
@@ -2161,7 +2161,7 @@ public enum XMaterial {
     }
 
     /**
-     * The data value of this material <a href="https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening">pre-flattening</a>.
+     * The data value of this material <a href="https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening">pre-flattening</a>.
      * <p>
      * Can be accessed with {@link ItemStack#getData()} then {@code MaterialData#getData()}
      * or {@link ItemStack#getDurability()} if not damageable.

--- a/src/main/java/com/cryptomorin/xseries/XPotion.java
+++ b/src/main/java/com/cryptomorin/xseries/XPotion.java
@@ -46,8 +46,8 @@ import java.util.stream.Collectors;
  * Amplifier: The amplifier of the effect, with level I having value 0. Optional, and defaults to level I.
  * <p>
  * EssentialsX Potions: https://github.com/EssentialsX/Essentials/blob/2.x/Essentials/src/com/earth2me/essentials/Potions.java
- * Status Effect: https://minecraft.gamepedia.com/Status_effect
- * Potions: https://minecraft.gamepedia.com/Potion
+ * Status Effect: https://minecraft.wiki/w/Status_effect
+ * Potions: https://minecraft.wiki/w/Potion
  *
  * @author Crypto Morin
  * @version 3.1.0

--- a/src/main/java/com/cryptomorin/xseries/XSound.java
+++ b/src/main/java/com/cryptomorin/xseries/XSound.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
  * 1.8: <a href="http://docs.codelanx.com/Bukkit/1.8/org/bukkit/Sound.html">Sound Enum</a>
  * Latest: <a href="https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html">Sound Enum</a>
  * Basics: <a href="https://bukkit.org/threads/151517/">Bukkit Thread</a>
- * play command: <a href="https://minecraft.gamepedia.com/Commands/play">minecraft.gamepedia.com</a>
+ * play command: <a href="https://minecraft.wiki/w/Commands/play">minecraft.wiki/w</a>
  *
  * @author Crypto Morin
  * @version 9.2.0

--- a/src/main/java/com/cryptomorin/xseries/messages/ActionBar.java
+++ b/src/main/java/com/cryptomorin/xseries/messages/ActionBar.java
@@ -47,7 +47,7 @@ import static com.cryptomorin.xseries.ReflectionUtils.*;
  * Messages are not colorized by default.
  * <p>
  * Action bars are text messages that appear above
- * the player's <a href="https://minecraft.gamepedia.com/Heads-up_display">hotbar</a>
+ * the player's <a href="https://minecraft.wiki/w/Heads-up_display">hotbar</a>
  * Note that this is different from the text appeared when switching between items.
  * Those messages show the item's name and are different from action bars.
  * The only natural way of displaying action bars is when mounting.

--- a/src/main/java/com/cryptomorin/xseries/messages/Titles.java
+++ b/src/main/java/com/cryptomorin/xseries/messages/Titles.java
@@ -42,7 +42,7 @@ import java.util.function.Function;
  * Messages are not colorized by default.
  * <p>
  * Titles are text messages that appear in the
- * middle of the players screen: https://minecraft.gamepedia.com/Commands/title
+ * middle of the players screen: https://minecraft.wiki/w/Commands/title
  * PacketPlayOutTitle: https://wiki.vg/Protocol#Title
  *
  * @author Crypto Morin

--- a/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
@@ -99,7 +99,7 @@ import java.util.function.BooleanSupplier;
  * <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html">Java {@link Math}</a><br>
  * Getting started with <a href="https://www.spigotmc.org/wiki/vector-programming-for-beginners/">Vectors</a><br>
  * Extra stuff if you want to read more: https://www.spigotmc.org/threads/418399/<br>
- * Particles: https://minecraft.gamepedia.com/Particles<br>
+ * Particles: https://minecraft.wiki/w/Particles<br>
  * <p>
  * This class also uses {@link BooleanSupplier} and {@link Runnable} for repeating/delayed tasks
  * in order to be compatible with other server softwares such as <a href="https://papermc.io/software/folia">Folia</a>.


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.