### PR TITLE
Fix issues for 1.20.2 (#226)

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/SkullUtils.java
+++ b/src/main/java/com/cryptomorin/xseries/SkullUtils.java
@@ -195,7 +195,7 @@ public class SkullUtils {
 
     @Nonnull
     public static GameProfile profileFromBase64(String value) {
-        GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+        GameProfile profile = new GameProfile(UUID.randomUUID(), "");
         profile.getProperties().put("textures", new Property("textures", value));
         return profile;
     }


### PR DESCRIPTION
This PR fixes the issue mentioned in #226 as well as an NPE that occurs when trying to use SkullUtils.

I recognize the contributing guidelines say that changes shouldn't be made around the time a new minecraft version is released, but it's been over a week since 1.20.2 dropped, and I heard CryptoMorin is busy, so here's this. I've tried to keep the changes small and sensible, but if more changes are needed or if you'd like to just rewrite the changes from scratch, let me know.

The main change here is that the packet send method has been abstracted from `ServerGamePacketListenerImpl` to `ServerCommonPacketListenerImpl`. This change unfortunately occurred in its entirety across a "bug fix" version, so I've modified the `VersionHandler` class to accept patch versions as well, using overloading.

The other change is to simply replace `null` with `""` when creating a `GameProfile`, since the `name` parameter is now null-checked. It doesn't seem to affect functionality.

I've tested these changes on 1.20.1 and 1.20.2, and briefly on 1.8.8, and all seemed fine.