### PR TITLE
Fix java.lang.invoke.WrongMethodTypeException:

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/NMSExtras.java
+++ b/src/main/java/com/cryptomorin/xseries/NMSExtras.java
@@ -558,8 +558,23 @@ public final class NMSExtras {
         Location location = chest.getLocation();
         try {
             Object world = WORLD_HANDLE.invoke(location.getWorld());
-            Object position = v(19, BLOCK_POSITION.invoke(location.getBlockX(), location.getBlockY(), location.getBlockZ()))
-                    .orElse(BLOCK_POSITION.invoke(location.getX(), location.getY(), location.getZ()));
+            Object position = v(19,
+                    () ->
+                    {
+                        try {
+                            return BLOCK_POSITION.invoke(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+                        } catch (Throwable e) {
+                            throw new RuntimeException(e);
+                        }
+                    }).orElse(
+                    () ->
+                    {
+                        try {
+                            return BLOCK_POSITION.invoke(location.getX(), location.getY(), location.getZ());
+                        } catch (Throwable e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
             Object block = GET_BLOCK.invoke(GET_BLOCK_TYPE.invoke(world, position));
             PLAY_BLOCK_ACTION.invoke(world, position, block, 1, open ? 1 : 0);
         } catch (Throwable throwable) {

--- a/src/main/java/com/cryptomorin/xseries/NMSExtras.java
+++ b/src/main/java/com/cryptomorin/xseries/NMSExtras.java
@@ -558,7 +558,7 @@ public final class NMSExtras {
         Location location = chest.getLocation();
         try {
             Object world = WORLD_HANDLE.invoke(location.getWorld());
-            Object position = BLOCK_POSITION.invoke(location.getX(), location.getY(), location.getZ());
+            Object position = BLOCK_POSITION.invoke(location.getBlockX(), location.getBlockY(), location.getBlockZ());
             Object block = GET_BLOCK.invoke(GET_BLOCK_TYPE.invoke(world, position));
             PLAY_BLOCK_ACTION.invoke(world, position, block, 1, open ? 1 : 0);
         } catch (Throwable throwable) {

--- a/src/main/java/com/cryptomorin/xseries/NMSExtras.java
+++ b/src/main/java/com/cryptomorin/xseries/NMSExtras.java
@@ -558,7 +558,8 @@ public final class NMSExtras {
         Location location = chest.getLocation();
         try {
             Object world = WORLD_HANDLE.invoke(location.getWorld());
-            Object position = BLOCK_POSITION.invoke(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+            Object position = v(19, BLOCK_POSITION.invoke(location.getBlockX(), location.getBlockY(), location.getBlockZ()))
+                    .orElse(BLOCK_POSITION.invoke(location.getX(), location.getY(), location.getZ()));
             Object block = GET_BLOCK.invoke(GET_BLOCK_TYPE.invoke(world, position));
             PLAY_BLOCK_ACTION.invoke(world, position, block, 1, open ? 1 : 0);
         } catch (Throwable throwable) {


### PR DESCRIPTION
Fixed a WrongMethodTypeException thrown when the chest open animation method has been called.

Original error:
`
[13:24:00 WARN]: java.lang.invoke.WrongMethodTypeException: cannot convert MethodHandle(int,int,int)BlockPosition to (double,double,double)Object
[13:24:00 WARN]:        at java.base/java.lang.invoke.MethodHandle.asTypeUncached(MethodHandle.java:884)
[13:24:00 WARN]:        at java.base/java.lang.invoke.MethodHandle.asType(MethodHandle.java:869)
[13:24:00 WARN]:        at java.base/java.lang.invoke.Invokers.checkGenericType(Invokers.java:542)
[13:24:00 WARN]:        at ZombieSurvival-Revamped-1.0.0-all.jar//sv.file14.zs.shaded.xseries.xseries.NMSExtras.chest(NMSExtras.java:561)
[13:24:00 WARN]:        at ZombieSurvival-Revamped-1.0.0-all.jar//sv.file14.zombiesurvival.util.NMSUtil.playChestAnimation(NMSUtil.java:104)
[13:24:00 WARN]:        at ZombieSurvival-Revamped-1.0.0-all.jar//sv.file14.zombiesurvival.gameSign.MysteryBoxSign.doEvent(MysteryBoxSign.java:70)
[13:24:00 WARN]:        at ZombieSurvival-Revamped-1.0.0-all.jar//sv.file14.zombiesurvival.listener.PlayerInteract.onEvent(PlayerInteract.java:84)
`