### PR TITLE
[XItemStack] XItemStack.edit() removes unbreakable state when not specified in the config

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -929,7 +929,7 @@ public final class XItemStack {
             meta.setDisplayName(" "); // For GUI easy access configuration purposes
 
         // Unbreakable
-        if (supports(11) && config.contains("unbreakable")) meta.setUnbreakable(config.getBoolean("unbreakable"));
+        if (supports(11) && config.isSet("unbreakable")) meta.setUnbreakable(config.getBoolean("unbreakable"));
 
         // Custom Model Data
         if (supports(14)) {

--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -929,7 +929,7 @@ public final class XItemStack {
             meta.setDisplayName(" "); // For GUI easy access configuration purposes
 
         // Unbreakable
-        if (supports(11)) meta.setUnbreakable(config.getBoolean("unbreakable"));
+        if (supports(11) && config.contains("unbreakable")) meta.setUnbreakable(config.getBoolean("unbreakable"));
 
         // Custom Model Data
         if (supports(14)) {


### PR DESCRIPTION
```java
// Unbreakable item
ItemStack item = new ItemStack(Material.DIAMOND_SWORD);
ItemMeta meta = item.getItemMeta();
meta.setUnbreakable(true);
item.setItemMeta(meta);

ConfigurationSection config = new YamlConfiguration(); // empty config
// The item is no longer unbreakable
ItemStack sameItem = XItemStack.edit(item, config, Function.identity(), null);
```