### PR TITLE
feat: add cocoa as crop

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XBlock.java
+++ b/src/main/java/com/cryptomorin/xseries/XBlock.java
@@ -63,7 +63,7 @@ public final class XBlock {
             XMaterial.MELON_SEEDS, XMaterial.BEETROOT_SEEDS, XMaterial.BEETROOTS, XMaterial.SUGAR_CANE,
             XMaterial.BAMBOO_SAPLING, XMaterial.BAMBOO, XMaterial.CHORUS_PLANT,
             XMaterial.KELP, XMaterial.KELP_PLANT, XMaterial.SEA_PICKLE, XMaterial.BROWN_MUSHROOM, XMaterial.RED_MUSHROOM,
-            XMaterial.MELON_STEM, XMaterial.PUMPKIN_STEM
+            XMaterial.MELON_STEM, XMaterial.PUMPKIN_STEM, XMaterial.COCOA, XMaterial.COCOA_BEANS
 
     ));
     public static final Set<XMaterial> DANGEROUS = Collections.unmodifiableSet(EnumSet.of(


### PR DESCRIPTION
Add cocoa as a crop, there are probably more blocks that should be considered as a crop, I can't identify them all right now, but this is another one that was missing.