### PR TITLE
[XParticle] Correct `CRIT_MAGIC -> ENCHANTED_HIT`

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
@@ -29,11 +29,11 @@ public enum XParticle {
     SPLASH,
     FISHING,
     UNDERWATER,
+    CRIT,
     /**
-     * CRIT_MAGIC -> CRIT (v1.20.5)
+     * CRIT_MAGIC -> ENCHANTED_HIT (v1.20.5)
      */
-    CRIT("CRIT_MAGIC"),
-    ENCHANTED_HIT,
+    ENCHANTED_HIT("CRIT_MAGIC"),
     SMOKE,
     /**
      * SMOKE_LARGE -> LARGE_SMOKE (v1.20.5)


### PR DESCRIPTION
Currently, in XParticle, `CRIT_MAGIC` [is said](https://github.com/CryptoMorin/XSeries/blob/d1bf398eba41bdf81857d1c297253bc2066505b7/src/main/java/com/cryptomorin/xseries/particles/XParticle.java#L33) to have been changed to `CRIT` in 1.20.5, but this doesn't seem to be correct based on [this diff](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/diff/src/main/java/org/bukkit/Particle.java?until=8a34e009148cc297bcc9eb5c250fc4f5b071c4a7). Based on that, it looks like `CRIT` is unchanged and `CRIT_MAGIC` has been changed to `ENCHANTED_HIT`. This PR fixes that so the `ENCHANTED_HIT`/`CRIT_MAGIC` particle works correctly on 1.20.4 and under.