### PR TITLE
[XParticle] BARRIER, LIGHT -> BLOCK_MARKER (v1.18)

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
@@ -166,7 +166,10 @@ public enum XParticle {
     RAID_OMEN,
     @MinecraftExperimental(Requires.UPDATE_1_21)
     TRIAL_OMEN,
-    BLOCK_MARKER;
+    /**
+     * BARRIER, LIGHT -> BLOCK_MARKER (v1.18)
+     */
+    BLOCK_MARKER("BARRIER", "LIGHT");
 
     private final Particle particle;
 


### PR DESCRIPTION
In MC v1.18, the removed `BARRIER` and `LIGHT` particles in favor of the `BLOCK_MARKER` particle. More info here: https://minecraft.fandom.com/wiki/Particles

I feel that it is appropriate to have barrier and light as alternatives... though that is slightly opinionated since the new version of the particle requires block data to be sent. 