### PR TITLE
[XParticle] add BLOCK_CRACK alt for BLOCK particle

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
@@ -71,7 +71,10 @@ public enum XParticle {
     ITEM_SLIME,
     HEART,
     ITEM,
-    BLOCK,
+    /**
+     * BLOCK_CRACK -> BLOCK (v1.20.5)
+     */
+    BLOCK("BLOCK_CRACK"),
     RAIN,
     /**
      * MOB_APPEARANCE -> ELDER_GUARDIAN (v1.20.5)

--- a/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/XParticle.java
@@ -72,9 +72,9 @@ public enum XParticle {
     HEART,
     ITEM,
     /**
-     * BLOCK_CRACK -> BLOCK (v1.20.5)
+     * BLOCK_CRACK, BLOCK_DUST -> BLOCK (v1.20.5)
      */
-    BLOCK("BLOCK_CRACK"),
+    BLOCK("BLOCK_CRACK", "BLOCK_DUST"),
     RAIN,
     /**
      * MOB_APPEARANCE -> ELDER_GUARDIAN (v1.20.5)


### PR DESCRIPTION
The `XParticle.BLOCK` enum is missing `BLOCK_CRACK` as an alt. `BLOCK_CRACK` was removed in 1.20.5 in favor of `BLOCK`