### PR TITLE
[XReflection] Fix load error on versions with no patch

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/reflection/XReflection.java
+++ b/src/main/java/com/cryptomorin/xseries/reflection/XReflection.java
@@ -154,7 +154,7 @@ public final class XReflection {
         // Bukkit.getVersion()       = git-Paper-364 (MC: 1.20.4)
         Matcher bukkitVer = Pattern
                 // <patch> is optional for first releases like "1.8-R0.1-SNAPSHOT"
-                .compile("^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?")
+                .compile("^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?")
                 .matcher(Bukkit.getBukkitVersion());
         if (bukkitVer.find()) { // matches() won't work, we just want to match the start using "^"
             try {


### PR DESCRIPTION
Using XSeries on Spigot 1.20(.0) results in this error in my plugin:
```
java.lang.ExceptionInInitializerError: null
        at be.isach.ultracosmetics.shaded.xseries.XSkull.<clinit>(XSkull.java:138) ~[?:?]
        at be.isach.ultracosmetics.util.ItemFactory.createSkull(ItemFactory.java:188) ~[?:?]
        at be.isach.ultracosmetics.cosmetics.type.HatType.<init>(HatType.java:36) ~[?:?]
        at be.isach.ultracosmetics.cosmetics.type.HatType.register(HatType.java:79) ~[?:?]
        at be.isach.ultracosmetics.cosmetics.type.CosmeticType.registerAll(CosmeticType.java:99) ~[?:?]
        at be.isach.ultracosmetics.UltraCosmetics.start(UltraCosmetics.java:311) ~[?:?]
        at be.isach.ultracosmetics.UltraCosmetics.onEnable(UltraCosmetics.java:213) ~[?:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:266) ~[spigot-api-1.20-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:342) ~[spigot-api-1.20-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:480) ~[spigot-api-1.20-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_20_R1.CraftServer.enablePlugin(CraftServer.java:541) ~[spigot-1.20-R0.1-SNAPSHOT.jar:3782-Spigot-58b7c46-245f2be]
        at org.bukkit.craftbukkit.v1_20_R1.CraftServer.enablePlugins(CraftServer.java:455) ~[spigot-1.20-R0.1-SNAPSHOT.jar:3782-Spigot-58b7c46-245f2be]
        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:589) ~[spigot-1.20-R0.1-SNAPSHOT.jar:3782-Spigot-58b7c46-245f2be]
        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:414) ~[spigot-1.20-R0.1-SNAPSHOT.jar:3782-Spigot-58b7c46-245f2be]
        at net.minecraft.server.dedicated.DedicatedServer.e(DedicatedServer.java:250) ~[spigot-1.20-R0.1-SNAPSHOT.jar:3782-Spigot-58b7c46-245f2be]
        at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:973) ~[spigot-1.20-R0.1-SNAPSHOT.jar:3782-Spigot-58b7c46-245f2be]
        at net.minecraft.server.MinecraftServer.lambda$0(MinecraftServer.java:304) ~[spigot-1.20-R0.1-SNAPSHOT.jar:3782-Spigot-58b7c46-245f2be]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
Caused by: java.lang.IllegalStateException: Cannot parse server version: "1.20-R0.1-SNAPSHOT"                                                                         at be.isach.ultracosmetics.shaded.xseries.reflection.XReflection.<clinit>(XReflection.java:170) ~[?:?]
        ... 18 more
```
This seems to be due to the patch *number* being marked optional, but not the dot between the minor number and patch number. This PR fixes this using a non-capture group to ensure they're either both present or both absent from the match.

I've verified this works both on 1.20 and versions with a minor revision, like 1.20.6