### PR TITLE
[ParticleDisplay] Be generally more user-friendly

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -1515,7 +1515,7 @@ public class ParticleDisplay implements Cloneable {
      */
     @Nonnull
     public ParticleDisplay directional() {
-        count = 0;
+        particleDirection = new Vector();
         return this;
     }
 

--- a/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -547,7 +547,7 @@ public class ParticleDisplay implements Cloneable {
                 }
 
                 if (parsedColor2 != null) {
-                    display.data = new DustTransitionParticleColor(parsedColor1, parsedColor2);
+                    display.data = new DustTransitionParticleColor(parsedColor1, parsedColor2, size);
                 } else {
                     display.data = new RGBParticleColor(parsedColor1);
                 }
@@ -983,7 +983,7 @@ public class ParticleDisplay implements Cloneable {
      */
     @Nonnull
     public ParticleDisplay withTransitionColor(@Nonnull Color fromColor, float size, @Nonnull Color toColor) {
-        this.data = new DustTransitionParticleColor(fromColor, toColor);
+        this.data = new DustTransitionParticleColor(fromColor, toColor, size);
         this.extra = size;
         return this;
     }
@@ -1923,25 +1923,25 @@ public class ParticleDisplay implements Cloneable {
     }
 
     public static class DustTransitionParticleColor implements ParticleData {
-        private final Color fromColor;
-        private final Color toColor;
-        public DustTransitionParticleColor(Color fromColor, Color toColor) {
-            this.fromColor = fromColor;
-            this.toColor = toColor;
+        private final Particle.DustTransition dustTransition;
+        public DustTransitionParticleColor(Color fromColor, Color toColor, double size) {
+            this.dustTransition = new Particle.DustTransition(
+                    org.bukkit.Color.fromRGB(fromColor.getRed(), fromColor.getGreen(), fromColor.getBlue()),
+                    org.bukkit.Color.fromRGB(toColor.getRed(), toColor.getGreen(), toColor.getBlue()),
+                    (float) size
+            );
         }
 
         @Override
         public Object data(XParticle particle, double extra) {
-            return new Particle.DustTransition(
-                    org.bukkit.Color.fromRGB(fromColor.getRed(), fromColor.getGreen(), fromColor.getBlue()),
-                    org.bukkit.Color.fromRGB(toColor.getRed(), toColor.getGreen(), toColor.getBlue()),
-                    (float) extra
-            );
+            return dustTransition;
         }
 
         @Override
         public void serialize(ConfigurationSection section) {
             StringJoiner colorJoiner = new StringJoiner(", ");
+            org.bukkit.Color fromColor = dustTransition.getColor();
+            org.bukkit.Color toColor = dustTransition.getToColor();
             colorJoiner.add(Integer.toString(fromColor.getRed()));
             colorJoiner.add(Integer.toString(fromColor.getGreen()));
             colorJoiner.add(Integer.toString(fromColor.getBlue()));

--- a/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -885,6 +885,20 @@ public class ParticleDisplay implements Cloneable {
         return withColor(color, 1f);
     }
 
+    /**
+     * Adds note color properties to the particle settings.
+     * The particle must be {@link Particle#NOTE}
+     * for colors to work as expected.
+     *
+     * @param color the note number for the color (0-24, inclusive)
+     * @return the same particle display, but modified.
+     * @since 11.0.0
+     */
+    @Nonnull
+    public ParticleDisplay withNoteColor(int color) {
+        return withColor(color / 24f * 255, 0, 0, 1f).withCount(0);
+    }
+
     // public ParticleDisplay withSize(float size) {
     //     if (data == null) {
     //         this.data = new float[]{red, green, blue, size};

--- a/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -1648,6 +1648,9 @@ public class ParticleDisplay implements Cloneable {
         double dx = offset.getX();
         double dy = offset.getY();
         double dz = offset.getZ();
+        // The "extra" field has no effect on dust particles in some versions,
+        // but in others it causes the colors to not display when set to 0.
+        double extra = (this.particle == XParticle.DUST) ? 1 : this.extra;
         if (players == null)
             if (ISFLAT)
                 loc.getWorld().spawnParticle(particle, loc, count, dx, dy, dz, extra, data, force);
@@ -1870,7 +1873,9 @@ public class ParticleDisplay implements Cloneable {
             // ENTITY_EFFECT particle uses the offset fields for color on 1.20.4 and below.
             if (!ISFLAT || (display.particle == XParticle.ENTITY_EFFECT && display.particle.isSupported()
                     && display.particle.get().getDataType() == Void.class)) {
-                return new Vector(color.getRed() / 255d, color.getGreen() / 255d, color.getBlue() / 255d);
+                // Dust particles on older versions would ignore the red channel if it's set to 0.
+                double red = (color.getRed() == 0) ? Float.MIN_VALUE : color.getRed() / 255d;
+                return new Vector(red, color.getGreen() / 255d, color.getBlue() / 255d);
             }
             return null;
         }

--- a/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -41,6 +41,7 @@ import java.awt.*;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -81,6 +82,14 @@ public class ParticleDisplay implements Cloneable {
      */
     private static final boolean ISFLAT;
 
+    /**
+     * Checks if org.bukkit.Color supports colors with an alpha value.
+     * This was added in 1.19.4
+     *
+     * @since 11.0.0
+     */
+    private static final boolean SUPPORTS_ALPHA_COLORS;
+
     static {
         boolean isFlat;
         try {
@@ -93,6 +102,15 @@ public class ParticleDisplay implements Cloneable {
             isFlat = false;
         }
         ISFLAT = isFlat;
+
+        boolean supportsAlphaColors;
+        try {
+            org.bukkit.Color.fromARGB(0);
+            supportsAlphaColors = true;
+        } catch (NoSuchMethodError e) {
+            supportsAlphaColors = false;
+        }
+        SUPPORTS_ALPHA_COLORS = supportsAlphaColors;
     }
 
     /**
@@ -144,14 +162,20 @@ public class ParticleDisplay implements Cloneable {
     private static final XParticle DEFAULT_PARTICLE = XParticle.FLAME;
 
     public int count = 1;
+    /**
+     * "extra" is usually the particle speed, but it
+     * represents the size when used for dust particles.
+     */
     public double extra;
     public boolean force;
     @Nonnull
     private XParticle particle = DEFAULT_PARTICLE;
     @Nullable
     private Location location, lastLocation;
-    @Nullable
+    @Nonnull
     private Vector offset = new Vector();
+    @Nonnull
+    private Vector particleDirection = new Vector();
     /**
      * The direction is mostly used for APIs to call {@link #advanceInDirection(double)}
      * instead of handling the direction in a specific axis.
@@ -185,8 +209,7 @@ public class ParticleDisplay implements Cloneable {
     @Nullable
     private List<Quaternion> cachedFinalRotationQuaternions;
     @Nullable
-    private Object data;
-    private boolean isNoteColor = false;
+    private ParticleData data;
     @Nullable
     private Consumer<CalculationContext> preCalculation;
     @Nullable
@@ -434,6 +457,17 @@ public class ParticleDisplay implements Cloneable {
             }
         }
 
+        String particleDirection = config.getString("direction");
+        if (particleDirection != null) {
+            List<String> directions = split(particleDirection.replace(" ", ""), ',');
+            if (directions.size() >= 3) {
+                double directionx = toDouble(directions.get(0));
+                double directiony = toDouble(directions.get(1));
+                double directionz = toDouble(directions.get(2));
+                display.particleDirection(directionx, directiony, directionz);
+            }
+        }
+
         ConfigurationSection rotations = config.getConfigurationSection("rotations");
         if (rotations != null) {
             /*
@@ -481,17 +515,12 @@ public class ParticleDisplay implements Cloneable {
         String item = config.getString("itemstack");            // material name
         String materialdata = config.getString("materialdata"); // material name
 
-        float size;
+        double size;
         if (config.isSet("size")) {
-            size = (float) config.getDouble("size");
-            if (display.data instanceof float[]) {
-                float[] datas = (float[]) display.data;
-                if (datas.length > 3) {
-                    datas[3] = size;
-                }
-            }
+            size = config.getDouble("size");
+            display.extra = size;
         } else {
-            size = 1f;
+            size = 1;
         }
 
         if (color != null) {
@@ -518,32 +547,25 @@ public class ParticleDisplay implements Cloneable {
                 }
 
                 if (parsedColor2 != null) {
-                    display.data = new float[]{
-                            parsedColor1.getRed(), parsedColor1.getGreen(), parsedColor1.getBlue(),
-                            size,
-                            parsedColor2.getRed(), parsedColor2.getGreen(), parsedColor2.getBlue()
-                    };
+                    display.data = new DustTransitionParticleColor(parsedColor1, parsedColor2);
                 } else {
-                    display.data = new float[]{
-                            parsedColor1.getRed(), parsedColor1.getGreen(), parsedColor1.getBlue(),
-                            size
-                    };
+                    display.data = new RGBParticleColor(parsedColor1);
                 }
             }
         } else if (blockdata != null) {
             Material material = Material.getMaterial(blockdata);
             if (material != null && material.isBlock()) {
-                display.data = material.createBlockData();
+                display.data = new ParticleBlockData(material.createBlockData());
             }
         } else if (item != null) {
             Material material = Material.getMaterial(item);
             if (material != null && material.isItem()) {
-                display.data = new ItemStack(material, 1);
+                display.data = new ParticleItemData(new ItemStack(material, 1));
             }
         } else if (materialdata != null) {
             Material material = Material.getMaterial(materialdata);
             if (material != null && material.isBlock()) {
-                display.data = material.getData();
+                display.data = new ParticleMaterialData(material.getNewData((byte) 0));
             }
         }
 
@@ -572,9 +594,14 @@ public class ParticleDisplay implements Cloneable {
             section.set("force", true);
         }
 
-        if (display.offset != null) {
+        if (!isZero(display.offset)) {
             Vector offset = display.offset;
             section.set("offset", offset.getX() + ", " + offset.getY() + ", " + offset.getZ());
+        }
+
+        if (!isZero(display.particleDirection)) {
+            Vector direction = display.particleDirection;
+            section.set("direction", direction.getX() + ", " + direction.getY() + ", " + direction.getZ());
         }
 
         if (!display.rotations.isEmpty()) {
@@ -604,38 +631,8 @@ public class ParticleDisplay implements Cloneable {
             }
         }
 
-        if (display.data instanceof float[]) {
-            float size = 1f;
-            float[] datas = (float[]) display.data;
-            StringJoiner colorJoiner = new StringJoiner(", ");
-            if (datas.length >= 3) {
-                if (datas.length > 3) {
-                    size = datas[3];
-                }
-                Color color1 = new Color(datas[0], datas[1], datas[2]);
-                colorJoiner.add(Integer.toString(color1.getRed()));
-                colorJoiner.add(Integer.toString(color1.getGreen()));
-                colorJoiner.add(Integer.toString(color1.getBlue()));
-            }
-            if (datas.length >= 7) {
-                Color color2 = new Color(datas[4], datas[5], datas[6]);
-                colorJoiner.add(Integer.toString(color2.getRed()));
-                colorJoiner.add(Integer.toString(color2.getGreen()));
-                colorJoiner.add(Integer.toString(color2.getBlue()));
-            }
-            section.set("color", colorJoiner.toString());
-            section.set("size", size);
-        }
-
-        if (ISFLAT) {
-            if (display.data instanceof BlockData) {
-                section.set("blockdata", ((BlockData) display.data).getMaterial().name());
-            }
-        }
-        if (display.data instanceof ItemStack) {
-            section.set("itemstack", ((ItemStack) display.data).getType().name());
-        } else if (display.data instanceof MaterialData) {
-            section.set("materialdata", ((MaterialData) display.data).getItemType().name());
+        if (display.data != null) {
+            display.data.serialize(section);
         }
     }
 
@@ -826,16 +823,22 @@ public class ParticleDisplay implements Cloneable {
     }
 
     /**
-     * Get the data object. Currently, it can be instance of float[] with [R, G, B, size],
-     * or instance of {@link BlockData}, {@link MaterialData} for legacy usage or {@link ItemStack}
+     * Get the data object.
      *
      * @return the data object.
      * @since 5.1.0
      */
-    @SuppressWarnings("deprecation")
     @Nullable
-    public Object getData() {
+    public ParticleData getData() {
         return data;
+    }
+
+    /**
+     * Sets the data object.
+     */
+    public ParticleDisplay withData(ParticleData data) {
+        this.data = data;
+        return this;
     }
 
     @Override
@@ -853,7 +856,7 @@ public class ParticleDisplay implements Cloneable {
 
                 "Extra=" + extra + ", " +
                 "Force=" + force + ", " +
-                "Data=" + (data == null ? "null" : data instanceof float[] ? Arrays.toString((float[]) data) : data);
+                "Data=" + data;
     }
 
     /**
@@ -931,9 +934,8 @@ public class ParticleDisplay implements Cloneable {
      */
     @Nonnull
     public ParticleDisplay withNoteColor(int color) {
-        this.data = new float[]{color / 24f * 255, 0, 0, 1f};
-        this.isNoteColor = true;
-        return withCount(0);
+        this.data = new NoteParticleColor(color);
+        return this;
     }
 
     /**
@@ -962,8 +964,8 @@ public class ParticleDisplay implements Cloneable {
     @Nonnull
     @Deprecated
     public ParticleDisplay withColor(float red, float green, float blue, float size) {
-        this.data = new float[]{red, green, blue, size};
-        this.isNoteColor = false;
+        this.data = new RGBParticleColor((int)red, (int)green, (int)blue);
+        this.extra = size;
         return this;
     }
 
@@ -981,11 +983,8 @@ public class ParticleDisplay implements Cloneable {
      */
     @Nonnull
     public ParticleDisplay withTransitionColor(@Nonnull Color fromColor, float size, @Nonnull Color toColor) {
-        this.data = new float[]{
-                fromColor.getRed(), fromColor.getGreen(), fromColor.getBlue(),
-                size,
-                toColor.getRed(), toColor.getGreen(), toColor.getBlue()
-        };
+        this.data = new DustTransitionParticleColor(fromColor, toColor);
+        this.extra = size;
         return this;
     }
 
@@ -998,8 +997,8 @@ public class ParticleDisplay implements Cloneable {
     public ParticleDisplay withTransitionColor(float red1, float green1, float blue1,
                                                float size,
                                                float red2, float green2, float blue2) {
-        this.data = new float[]{red1, green1, blue1, size, red2, green2, blue2};
-        return this;
+        return withTransitionColor(new Color((int)red1, (int)green1, (int)blue1), size,
+                new Color((int)red2, (int)green2, (int)blue2));
     }
 
     /**
@@ -1016,7 +1015,7 @@ public class ParticleDisplay implements Cloneable {
      */
     @Nonnull
     public ParticleDisplay withBlock(@Nonnull BlockData blockData) {
-        this.data = blockData;
+        this.data = new ParticleBlockData(blockData);
         return this;
     }
 
@@ -1035,7 +1034,7 @@ public class ParticleDisplay implements Cloneable {
     @SuppressWarnings("deprecation")
     @Nonnull
     public ParticleDisplay withBlock(@Nonnull MaterialData materialData) {
-        this.data = materialData;
+        this.data = new ParticleMaterialData(materialData);
         return this;
     }
 
@@ -1049,13 +1048,18 @@ public class ParticleDisplay implements Cloneable {
      */
     @Nonnull
     public ParticleDisplay withItem(@Nonnull ItemStack item) {
-        this.data = item;
+        this.data = new ParticleItemData(item);
         return this;
     }
 
-    @Nullable
+    @Nonnull
     public Vector getOffset() {
         return offset;
+    }
+
+    @Nonnull
+    public Vector getParticleDirection() {
+        return direction;
     }
 
     /**
@@ -1170,6 +1174,13 @@ public class ParticleDisplay implements Cloneable {
     @Nonnull
     private static Location cloneLocation(@Nonnull Location location) {
         return new Location(location.getWorld(), location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
+    }
+
+    /**
+     * The method {@link Vector#isZero()} was not added until 1.19.3.
+     */
+    private static boolean isZero(@Nonnull Vector vector) {
+        return vector.getX() == 0 && vector.getY() == 0 && vector.getZ() == 0;
     }
 
     /**
@@ -1469,6 +1480,29 @@ public class ParticleDisplay implements Cloneable {
     }
 
     /**
+     * Set the xyz direction of a particle.
+     *
+     * @since 11.0.0
+     */
+    @Nonnull
+    public ParticleDisplay particleDirection(double x, double y, double z) {
+        return particleDirection(new Vector(x, y, z));
+    }
+
+    /**
+     * Set the xyz direction of a particle.
+     *
+     * @since 11.0.0
+     */
+    @Nonnull
+    public ParticleDisplay particleDirection(Vector particleDirection) {
+        this.particleDirection = particleDirection;
+        // Particle directions require a nonzero speed or the direction won't do anything.
+        if (extra == 0) extra = 1;
+        return this;
+    }
+
+    /**
      * When a particle is set to be directional it'll only
      * spawn one particle and the xyz offset values are used for
      * the direction of the particle.
@@ -1493,12 +1527,13 @@ public class ParticleDisplay implements Cloneable {
      * @since 2.1.0
      */
     public boolean isDirectional() {
-        return count == 0;
+        return !isZero(particleDirection);
     }
 
     /**
      * Spawns the particle at the current location.
      *
+     * @return the location the particle was spawned at.
      * @since 2.0.1
      */
     @Nullable
@@ -1511,6 +1546,7 @@ public class ParticleDisplay implements Cloneable {
      * spawning particles.
      *
      * @param local the xyz to add.
+     * @return the location the particle was spawned at.
      * @since 1.0.0
      */
     @Nullable
@@ -1521,6 +1557,7 @@ public class ParticleDisplay implements Cloneable {
     /**
      * Adds xyz to the cloned location before spawning particle.
      *
+     * @return the location the particle was spawned at.
      * @since 1.0.0
      */
     @Nullable
@@ -1533,89 +1570,91 @@ public class ParticleDisplay implements Cloneable {
      * This method does not support rotations if used directly.
      *
      * @param loc the location to display the particle at.
+     * @return the same location that was passed.
      * @see #spawn(double, double, double)
      * @since 5.0.0
      */
     @Nullable
     public Location spawn(Location loc) {
         if (loc == null) return null;
+        lastLocation = loc;
 
         Particle particle = this.particle.get();
-        Objects.requireNonNull(particle, () -> "Cannot unsupported particle: " + particle);
+        Objects.requireNonNull(particle, () -> "Cannot spawn unsupported particle: " + particle);
 
-        World world = loc.getWorld();
+        // Compatibility for previous versions of ParticleDisplay where
+        // count = 0 was required for certain particle data, e.g. directional particles.
+        if (count == 0) count = 1;
+
+        Object data = null;
+        if (this.data != null) {
+            this.data = this.data.transform(this.particle);
+            if (this.data.isOffsetBased(this.particle)) {
+                double[] offsetValues = this.data.offsetValues();
+                spawnWithDataInOffset(particle, loc, offsetValues, null);
+                return loc;
+            }
+            data = this.data.data(this.particle, this.extra);
+            // Checks without data or block crack, block dust, falling dust, item crack or if data isn't right type
+            if (!particle.getDataType().isInstance(data)) data = null;
+        }
+
+        if (!isZero(this.particleDirection)) {
+            double[] offsetData = {particleDirection.getX(), particleDirection.getY(), particleDirection.getZ()};
+            spawnWithDataInOffset(particle, loc, offsetData, data);
+            return loc;
+        }
+
+        // Nothing weird, just spawn the particles normally.
         double offsetx = offset.getX();
         double offsety = offset.getY();
         double offsetz = offset.getZ();
-
-        if (data != null && data instanceof float[]) {
-            updateColorType();
-            float[] datas = (float[]) data;
-            if (ISFLAT && particle.getDataType() == Particle.DustOptions.class) {
-                Particle.DustOptions dust = new Particle.DustOptions(org.bukkit.Color
-                        .fromRGB((int) datas[0], (int) datas[1], (int) datas[2]), datas[3]);
-                if (players == null)
-                    world.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, dust, force);
-                else for (Player player : players)
-                    player.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, dust);
-            } else if (SUPPORTS_DUST_TRANSITION && particle.getDataType() == Particle.DustTransition.class) {
-                // Having the variable type as Particle.DustOptions causes NoClassDefFoundError for DustOptions
-                // because of some weird upcasting stuff.
-                Particle.DustTransition dust = new Particle.DustTransition(
-                        org.bukkit.Color.fromRGB((int) datas[0], (int) datas[1], (int) datas[2]),
-                        org.bukkit.Color.fromRGB((int) datas[4], (int) datas[5], (int) datas[6]),
-                        datas[3]);
-                if (players == null)
-                    world.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, dust, force);
-                else for (Player player : players)
-                    player.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, dust);
-            } else if (isDirectional()) {
-                // With count=0, color on offset e.g. for MOB_SPELL or 1.12 REDSTONE
-                float[] rgb = {datas[0] / 255f, datas[1] / 255f, datas[2] / 255f};
-                if (players == null) {
-                    if (ISFLAT)
-                        world.spawnParticle(particle, loc, count, rgb[0], rgb[1], rgb[2], datas[3], null, force);
-                    else world.spawnParticle(particle, loc, count, rgb[0], rgb[1], rgb[2], datas[3], null);
-                } else for (Player player : players)
-                    player.spawnParticle(particle, loc, count, rgb[0], rgb[1], rgb[2], datas[3]);
-
-            } else {
-                // Else color can't have any effect, keep default param
-                if (players == null) {
-                    if (ISFLAT)
-                        world.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, null, force);
-                    else world.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, null);
-                } else for (Player player : players)
-                    player.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra);
-            }
-        } else {
-            // Checks without data or block crack, block dust, falling dust, item crack or if data isn't right type
-            Object datas = particle.getDataType().isInstance(data) ? data : null;
-            if (players == null) {
-                if (ISFLAT) world.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, datas, force);
-                else world.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, datas);
-            } else for (Player player : players)
-                player.spawnParticle(particle, loc, count, offsetx, offsety, offsetz, extra, datas);
-        }
-
-        this.lastLocation = loc;
+        spawnRaw(particle, loc, count, offsetx, offsety, offsetz, data);
         return loc;
     }
 
-    private void updateColorType() {
-        if (data == null || !(data instanceof float[])) return;
-        float[] datas = (float[]) this.data;
-        if (this.particle == XParticle.NOTE) {
-            if (!isNoteColor) {
-                int nearestColor = findNearestNoteColor(new Color((int)datas[0], (int)datas[1], (int)datas[2]));
-                data = new float[]{nearestColor / 24f * 255, 0, 0, datas[3]};
-                isNoteColor = true;
-            }
-        } else if (isNoteColor) {
-            Color color = NOTE_COLORS[(int) (datas[0] / 255 * 24)];
-            data = new float[]{color.getRed(), color.getGreen(), color.getBlue(), datas[3]};
-            isNoteColor = false;
+    /**
+     * Spawns the particles with specific data in the offset fields.
+     * If required, this method will manually calculate an offset for
+     * each particle similarly to the standard behavior, and spawn the particles at those.
+     *
+     * @param offsetData the data that needs to go in the offset fields.
+     */
+    private void spawnWithDataInOffset(Particle particle, Location loc, double[] offsetData, Object data) {
+        // If there is no offset and we only want a single particle, we don't actually need to do anything special.
+        // Otherwise, we'll at least need to use a loop.
+        if (isZero(offset) && count < 2) {
+            spawnRaw(particle, loc, 0, offsetData[0], offsetData[1], offsetData[2], data);
+            return;
         }
+        // Particles with a specific direction must be flagged with count = 0,
+        // so we have to spawn each particle manually.
+        double offsetx = offset.getX();
+        double offsety = offset.getY();
+        double offsetz = offset.getZ();
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        for (int i = 0; i < count; i++) {
+            // When specifying an offset normally, bound of 1 gets you an 8 block range,
+            // being +/- 4 blocks in each direction from the origin. Uses a Gaussian distribution.
+            // Gaussian distribution uses a sqrt, so skip that if we can.
+            double dx = offsetx == 0 ? 0 : r.nextGaussian() * 4 * offsetx;
+            double dy = offsety == 0 ? 0 : r.nextGaussian() * 4 * offsety;
+            double dz = offsetz == 0 ? 0 : r.nextGaussian() * 4 * offsetz;
+            Location offsetLoc = cloneLocation(loc).add(dx, dy, dz);
+            spawnRaw(particle, offsetLoc, 0, offsetData[0], offsetData[1], offsetData[2], data);
+        }
+    }
+
+    /**
+     * Calls the appropriate spawnParticle method with the parameters given.
+     */
+    private void spawnRaw(Particle particle, Location loc, int count, double dx, double dy, double dz, Object data) {
+        if (players == null)
+            if (ISFLAT)
+                loc.getWorld().spawnParticle(particle, loc, count, dx, dy, dz, extra, data, force);
+            else loc.getWorld().spawnParticle(particle, loc, count, dx, dy, dz, extra, data);
+        else for (Player player : players)
+            player.spawnParticle(particle, loc, count, dx, dy, dz, extra, data);
     }
 
     /**
@@ -1792,6 +1831,223 @@ public class ParticleDisplay implements Cloneable {
             double vz = (xz - wy) * point.getX() + (yz + wx) * point.getY() + (1F - (xx + yy)) * point.getZ();
 
             return new Vector(vx, vy, vz);
+        }
+    }
+
+    public interface ParticleData {
+        /**
+         * Returns true if the data type uses the offset fields,
+         * and false if it uses the data field.
+         * Sometimes depends on the particle and version.
+         */
+        public default boolean isOffsetBased(XParticle particle) {
+            return false;
+        }
+
+        public default double[] offsetValues() {
+            return new double[]{0, 0, 0};
+        }
+
+        public Object data(XParticle particle, double extra);
+
+        public void serialize(ConfigurationSection section);
+
+        /**
+         * If this data doesn't support the given particle type but can be
+         * converted to a type that does, this method should return the appropriate
+         * ParticleData for that particle type.
+         * Used for converting RGB particle data to note block particle data.
+         */
+        public default ParticleData transform(XParticle particle) {
+            return this;
+        }
+    }
+
+    public static class RGBParticleColor implements ParticleData {
+        private final Color color;
+        public RGBParticleColor(Color color) {
+            this.color = color;
+        }
+
+        public RGBParticleColor(int r, int g, int b) {
+            this(new Color(r, g, b));
+        }
+
+        @Override
+        public boolean isOffsetBased(XParticle particle) {
+            // All colors were offset-based until 1.13
+            if (!ISFLAT) return true;
+            // ENTITY_EFFECT particle uses the offset fields for color on 1.20.4 and below.
+            return particle == XParticle.ENTITY_EFFECT && particle.isSupported() && particle.get().getDataType() == Void.class;
+        }
+
+        @Override
+        public double[] offsetValues() {
+            return new double[]{color.getRed() / 255d, color.getGreen() / 255d, color.getBlue() / 255d};
+        }
+
+        public Object data(XParticle particle, double extra) {
+            if (particle == XParticle.DUST) {
+                return new Particle.DustOptions(org.bukkit.Color.fromRGB(color.getRed(), color.getGreen(), color.getBlue()), (float) extra);
+            } else if (particle == XParticle.DUST_COLOR_TRANSITION) {
+                org.bukkit.Color color = org.bukkit.Color.fromRGB(this.color.getRed(), this.color.getGreen(), this.color.getBlue());
+                return new Particle.DustTransition(color, color, (float) extra);
+            }
+            if (SUPPORTS_ALPHA_COLORS) {
+                return org.bukkit.Color.fromARGB(color.getAlpha(), color.getRed(), color.getGreen(), color.getBlue());
+            } else {
+                return org.bukkit.Color.fromRGB(color.getRed(), color.getGreen(), color.getBlue());
+            }
+        }
+
+        @Override
+        public void serialize(ConfigurationSection section) {
+            StringJoiner colorJoiner = new StringJoiner(", ");
+            colorJoiner.add(Integer.toString(color.getRed()));
+            colorJoiner.add(Integer.toString(color.getGreen()));
+            colorJoiner.add(Integer.toString(color.getBlue()));
+            section.set("color", colorJoiner.toString());
+        }
+
+        @Override
+        public ParticleData transform(XParticle particle) {
+            if (particle == XParticle.NOTE) {
+                return asNoteColor();
+            }
+            return this;
+        }
+
+        public NoteParticleColor asNoteColor() {
+            return new NoteParticleColor(findNearestNoteColor(color));
+        }
+    }
+
+    public static class DustTransitionParticleColor implements ParticleData {
+        private final Color fromColor;
+        private final Color toColor;
+        public DustTransitionParticleColor(Color fromColor, Color toColor) {
+            this.fromColor = fromColor;
+            this.toColor = toColor;
+        }
+
+        @Override
+        public Object data(XParticle particle, double extra) {
+            return new Particle.DustTransition(
+                    org.bukkit.Color.fromRGB(fromColor.getRed(), fromColor.getGreen(), fromColor.getBlue()),
+                    org.bukkit.Color.fromRGB(toColor.getRed(), toColor.getGreen(), toColor.getBlue()),
+                    (float) extra
+            );
+        }
+
+        @Override
+        public void serialize(ConfigurationSection section) {
+            StringJoiner colorJoiner = new StringJoiner(", ");
+            colorJoiner.add(Integer.toString(fromColor.getRed()));
+            colorJoiner.add(Integer.toString(fromColor.getGreen()));
+            colorJoiner.add(Integer.toString(fromColor.getBlue()));
+            colorJoiner.add(Integer.toString(toColor.getRed()));
+            colorJoiner.add(Integer.toString(toColor.getGreen()));
+            colorJoiner.add(Integer.toString(toColor.getBlue()));
+            section.set("color", colorJoiner.toString());
+        }
+    }
+
+    /**
+     * Represents a color that a note particle can be.
+     */
+    public static class NoteParticleColor implements ParticleData {
+        private final int note;
+        public NoteParticleColor(int note) {
+            this.note = note;
+        }
+
+        @SuppressWarnings("deprecation")
+        public NoteParticleColor(Note note) {
+            this(note.getId());
+        }
+
+        @Override
+        public boolean isOffsetBased(XParticle particle) {
+            return true;
+        }
+
+        @Override
+        public double[] offsetValues() {
+            return new double[]{note / 24d, 0, 0};
+        }
+
+        @Override
+        public Object data(XParticle particle, double extra) {
+            return null;
+        }
+
+        @Override
+        public void serialize(ConfigurationSection section) {
+            section.set("color", note);
+        }
+
+        @Override
+        public ParticleData transform(XParticle particle) {
+            if (particle == XParticle.NOTE) {
+                return this;
+            }
+            return asRGBColor();
+        }
+
+        public RGBParticleColor asRGBColor() {
+            return new RGBParticleColor(NOTE_COLORS[note]);
+        }
+    }
+
+    public static class ParticleBlockData implements ParticleData {
+        private final BlockData blockData;
+        public ParticleBlockData(BlockData blockData) {
+            this.blockData = blockData;
+        }
+
+        @Override
+        public Object data(XParticle particle, double extra) {
+            return blockData;
+        }
+
+        @Override
+        public void serialize(ConfigurationSection section) {
+            section.set("blockdata", blockData.getMaterial().name());
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    public static class ParticleMaterialData implements ParticleData {
+        private final MaterialData materialData;
+        public ParticleMaterialData(MaterialData materialData) {
+            this.materialData = materialData;
+        }
+
+        @Override
+        public Object data(XParticle particle, double extra) {
+            return materialData;
+        }
+
+        @Override
+        public void serialize(ConfigurationSection section) {
+            section.set("materialdata", materialData.getItemType().name());
+        }
+    }
+
+    public static class ParticleItemData implements ParticleData {
+        private final ItemStack item;
+        public ParticleItemData(ItemStack item) {
+            this.item = item;
+        }
+
+        @Override
+        public Object data(XParticle particle, double extra) {
+            return item;
+        }
+
+        @Override
+        public void serialize(ConfigurationSection section) {
+            section.set("itemstack", item.getType());
         }
     }
 }

--- a/src/main/java/com/cryptomorin/xseries/particles/Particles.java
+++ b/src/main/java/com/cryptomorin/xseries/particles/Particles.java
@@ -294,7 +294,7 @@ public final class Particles {
                 double directionX = Math.cos(extension * phi);
                 double directionZ = Math.sin(extension * phi);
 
-                display.offset(directionX, display.getOffset().getY(), directionZ);
+                display.particleDirection(directionX, display.getOffset().getY(), directionZ);
             }
 
             display.spawn(x, 0, z);
@@ -696,7 +696,6 @@ public final class Particles {
      * @since 3.0.0
      */
     public static BooleanSupplier blackhole(int points, double radius, double rate, int mode, int time, ParticleDisplay display) {
-        display.directional();
         display.extra = 0.1;
 
         return new BooleanSupplier() {
@@ -720,7 +719,7 @@ public final class Particles {
                     double xDirection = -Math.cos(phi);
                     double zDirection = -Math.sin(phi);
 
-                    display.offset(xDirection, 0, zDirection);
+                    display.particleDirection(xDirection, 0, zDirection);
                     display.spawn(x, 0, z);
 
                     // The modes are done by random math methods that are
@@ -737,7 +736,7 @@ public final class Particles {
                         xDirection = -Math.cos(phi);
                         zDirection = -Math.sin(phi);
 
-                        display.offset(xDirection, 0, zDirection);
+                        display.particleDirection(xDirection, 0, zDirection);
                         display.spawn(x, 0, z);
                     }
                 }
@@ -899,7 +898,6 @@ public final class Particles {
      */
     public static Runnable vortex(int points, double rate, ParticleDisplay display) {
         double rateDiv = Math.PI / rate;
-        display.directional();
 
         return new Runnable() {
             double theta = 0;
@@ -919,7 +917,7 @@ public final class Particles {
                     double xDirection = Math.cos(angle);
                     double zDirection = Math.sin(angle);
 
-                    display.offset(xDirection, 0, zDirection);
+                    display.particleDirection(xDirection, 0, zDirection);
                     display.spawn(x, 0, z);
                 }
             }
@@ -1241,7 +1239,7 @@ public final class Particles {
                     double directionY = Math.sin(Math.atan2(y2, y1));
                     double directionZ = Math.sin(omega);
 
-                    display.offset(directionX, directionY, directionZ);
+                    display.particleDirection(directionX, directionY, directionZ);
                 }
 
                 display.spawn(x, y1, z);


### PR DESCRIPTION
**Description**
The note particles are a bit strange: they have 25 possible colors, which are indicated in the `dX`/`offsetX` parameter using a scaled value between 0 and 1 (and count must be 0 for this field to act as the color, otherwise it acts as an offset as usual.) This means that in order to spawn a specific color of note particle, I'm currently required to do something like this:
```java
display.withColor(new Color((noteColor / 24f) * 255, 0, 0)).withCount(0);
```
To make this more user-friendly, I've added a function `withNoteColor` that accepts the index of a note color to display, and does this calculation internally. (See [this](https://minecraft.wiki/w/Note_Block#Notes) wiki page for the possible colors).

There may be a better way to do this as well, I'm open to any feedback!