### PR TITLE
[XSkull] Legacy support

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/profiles/objects/Profileable.java
+++ b/src/main/java/com/cryptomorin/xseries/profiles/objects/Profileable.java
@@ -72,9 +72,7 @@ public interface Profileable {
                 String username = null;
                 if (profileable instanceof UsernameProfileable) {
                     username = ((UsernameProfileable) profileable).username;
-                } else if (profileable instanceof PlayerProfileable) {
-                    username = ((PlayerProfileable) profileable).player.getName();
-                } else if (profileable instanceof OfflinePlayerProfileable) {
+                }  else if (profileable instanceof OfflinePlayerProfileable) {
                     username = ((OfflinePlayerProfileable) profileable).player.getName();
                 } else if (profileable instanceof StringProfileable) {
                     if (((StringProfileable) profileable).determineType().type == ProfileInputType.USERNAME) {
@@ -140,15 +138,6 @@ public interface Profileable {
      */
     static Profileable of(GameProfile profile) {
         return new GameProfileProfileable(profile);
-    }
-
-    /**
-     * Sets the skull texture based on the specified player.
-     *
-     * @param player The player to generate the {@link GameProfile}.
-     */
-    static Profileable of(Player player) {
-        return new PlayerProfileable(player);
     }
 
     /**
@@ -242,21 +231,6 @@ public interface Profileable {
                     ? new UUIDProfileable(profile.getId())
                     : new UsernameProfileable(profile.getName()))
                     .getProfile();
-        }
-    }
-
-    final class PlayerProfileable extends AbstractProfileable {
-        private final Player player;
-
-        public PlayerProfileable(Player player) {this.player = Objects.requireNonNull(player);}
-
-        @Override
-        public GameProfile getProfile0() {
-            // Why are we using the username instead of getting the cached UUID like profile(player.getUniqueId())?
-            // If it's about online/offline mode support why should we have a separate method for this instead of
-            // letting profile(OfflinePlayer) to take care of it?
-            if (PlayerUUIDs.isOnlineMode()) return new UUIDProfileable(player.getUniqueId()).getProfile();
-            return new UsernameProfileable(player.getName()).getProfile();
         }
     }
 


### PR DESCRIPTION
This PR fixes #273 and some other minor bugs 

### Changes
- Fix `MojangAPI.MOJANG_PROFILE_CACHE` condition
- Fix `ProfilesCore.UserCacheEntry_getProfile` not being accessible
- Fix remaps for `UserCache_profilesByUUID` and `UserCache_profilesByName`
- Remove unused reflected methods/fields
- Remove `Profileable#of(Player)`
<img width="1500" alt="Screenshot 2024-06-20 at 9 24 37 AM" src="https://github.com/CryptoMorin/XSeries/assets/48872538/178b89ea-7f58-488f-81b6-fd4a99eaba4c">
<img width="1512" alt="Screenshot 2024-06-20 at 9 26 12 AM" src="https://github.com/CryptoMorin/XSeries/assets/48872538/1a169434-0b4b-42cf-b674-fb77e7e82897">
<img width="1507" alt="Screenshot 2024-06-20 at 9 28 14 AM" src="https://github.com/CryptoMorin/XSeries/assets/48872538/8a1dc542-170c-4d79-b813-f34948f598e4">

