### PR TITLE
[XSkull] Support 1.20.1-1.20.5 proxy mappings

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/profiles/ProfilesCore.java
+++ b/src/main/java/com/cryptomorin/xseries/profiles/ProfilesCore.java
@@ -126,7 +126,11 @@ public final class ProfilesCore {
 
             // Some versions don't have the public getProxy() method. It's very inconsistent...
             proxy = (Proxy) MinecraftServer.field("protected final java.net.Proxy proxy;").getter()
-                    .map(MinecraftMapping.OBFUSCATED, v(20, "h").v(17, "m")
+                    .map(MinecraftMapping.OBFUSCATED,
+                v(20,5, "h")
+                                 .v(20,3, "i")
+                                 .v(20, 1, "j")
+                            .v(17, "m")
                             .v(14, "proxy") // v1.14 -> v1.16
                             .v(13, "c").orElse(/* v1.8 and v1.9 */ "e"))
                     .unreflect().invoke(minecraftServer);


### PR DESCRIPTION
This pr fixes the mappings for the proxy. You can also confirm those mappings by https://mappings.cephx.dev/