### PR TITLE
[XItemStack] Support hex colors

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -1137,6 +1137,11 @@ public final class XItemStack {
     /**
      * Parses RGB color codes from a string.
      * This only works for 1.13 and above.
+     * Accepts the following formats:
+     * "r, g, b"
+     * "#RRGGBB"
+     * decimal number representing "r << 16 | g << 8 | b"
+     * (format "0xRRGGBB" is converted to decimal by SnakeYAML and handled as such)
      *
      * @param str the RGB string.
      * @return a color based on the RGB.
@@ -1146,8 +1151,23 @@ public final class XItemStack {
     public static Color parseColor(@Nullable String str) {
         if (Strings.isNullOrEmpty(str)) return Color.BLACK;
         List<String> rgb = split(str.replace(" ", ""), ',');
-        if (rgb.size() < 3) return Color.WHITE;
-        return Color.fromRGB(toInt(rgb.get(0), 0), toInt(rgb.get(1), 0), toInt(rgb.get(2), 0));
+        if (rgb.size() == 3) {
+            return Color.fromRGB(toInt(rgb.get(0), 0), toInt(rgb.get(1), 0), toInt(rgb.get(2), 0));
+        }
+        // If we read a number that starts with 0x, SnakeYAML has already converted it to base-10
+        try {
+            return Color.fromRGB(Integer.parseInt(str));
+        } catch (NumberFormatException ignored) {
+        }
+        // Trim any prefix, parseInt only accepts digits
+        if (str.startsWith("#")) {
+            str = str.substring(1);
+        }
+        try {
+            return Color.fromRGB(Integer.parseInt(str, 16));
+        } catch (NumberFormatException e) {
+            return Color.WHITE;
+        }
     }
 
     /**


### PR DESCRIPTION
In the XItemStack docs, `Color` is defined as:
```
alias Color: for Text "red, green, blue" or "hex color"
```
However, XItemStack actually doesn't currently parse hex colors, only the comma-separated format is supported. This PR changes that, and now all of the following formats are supported:
- `r, g, b` (just like before)
- `#RRGGBB`
- `0xRRGGBB`
- decimal representation of `r << 16 | g << 8 | b`, as used in NBT

### Notes

The hex representation is automatically converted to decimal by SnakeYAML (and then converted to a string), so that format and the decimal representation end up being handled the same in the code. The bare format `RRGGBB` is also supported if it can't be parsed as a base-10 number, but due to that restriction I don't recommend that.