### PR TITLE
[XSkull] Support v1.21.1b78+ ResolvableProfile

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/profiles/ProfilesCore.java
+++ b/src/main/java/com/cryptomorin/xseries/profiles/ProfilesCore.java
@@ -65,7 +65,14 @@ public final class ProfilesCore {
             MinecraftClassHandle ResolvableProfile =
                     ns.ofMinecraft("package nms.world.item.component; public class ResolvableProfile {}");
 
-            boolean useResolvableProfile = CraftMetaSkull.field("private ResolvableProfile profile;").getter().exists();
+            boolean useResolvableProfile;
+            try {
+                CraftMetaSkull.field("private ResolvableProfile profile;").getter().exists();
+                useResolvableProfile = true;
+            }catch (Exception e) {
+                // catch Unknown type 'ResolvableProfile' -> 'ResolvableProfile' if type is GameProfile
+                useResolvableProfile = false;
+            }
 
             if(useResolvableProfile) {
                 newResolvableProfile = ResolvableProfile.constructor("public ResolvableProfile(GameProfile gameProfile);").reflect();
@@ -163,9 +170,11 @@ public final class ProfilesCore {
                 "package cb.block; public class CraftSkull extends CraftBlockEntityState implements Skull {}"
         );
 
-        FieldMemberHandle craftProfile = CraftSkull.field("private ResolvableProfile profile;");
-
-        if(!craftProfile.getter().exists()) {
+        FieldMemberHandle craftProfile;
+        try {
+            craftProfile = CraftSkull.field("private ResolvableProfile profile;");
+        }catch (Exception e) {
+            // catch Unknown type 'ResolvableProfile' -> 'ResolvableProfile' if type is GameProfile
             craftProfile = CraftSkull.field("private GameProfile profile;");
         }
 

--- a/src/main/java/com/cryptomorin/xseries/profiles/ProfilesCore.java
+++ b/src/main/java/com/cryptomorin/xseries/profiles/ProfilesCore.java
@@ -36,7 +36,7 @@ public final class ProfilesCore {
             FILL_PROFILE_PROPERTIES, GET_PROFILE_BY_NAME, GET_PROFILE_BY_UUID, CACHE_PROFILE,
             CRAFT_META_SKULL_PROFILE_GETTER, CRAFT_META_SKULL_PROFILE_SETTER,
             CRAFT_SKULL_PROFILE_SETTER, CRAFT_SKULL_PROFILE_GETTER,
-            Property_getValue, UserCache_getNextOperation, UserCacheEntry_getProfile, UserCacheEntry_setLastAccess;
+            Property_getValue, UserCache_getNextOperation, UserCacheEntry_getProfile, UserCacheEntry_setLastAccess, ResolvableProfile_constructor, ResolvableProfile_getGameProfile;
 
     /**
      * In v1.20.2, Mojang switched to {@code record} class types for their {@link Property} class.
@@ -48,6 +48,7 @@ public final class ProfilesCore {
         Proxy proxy;
         MethodHandle fillProfileProperties = null, getProfileByName, getProfileByUUID, cacheProfile;
         MethodHandle profileSetterMeta, profileGetterMeta;
+        MethodHandle newResolvableProfile = null, getGameProfile = null;
 
         ReflectiveNamespace ns = XReflection.namespaced()
                 .imports(GameProfile.class, MinecraftSessionService.class, LoadingCache.class);
@@ -60,14 +61,30 @@ public final class ProfilesCore {
             MinecraftClassHandle CraftMetaSkull = ns.ofMinecraft(
                     "package cb.inventory; class CraftMetaSkull extends CraftMetaItem implements SkullMeta {}"
             );
-            profileGetterMeta = CraftMetaSkull.field("private GameProfile profile;").getter().reflect();
 
-            try {
-                // https://github.com/CryptoMorin/XSeries/issues/169
-                // noinspection MethodMayBeStatic
-                profileSetterMeta = CraftMetaSkull.method("private void setProfile(GameProfile profile);").reflect();
-            } catch (NoSuchMethodException e) {
-                profileSetterMeta = CraftMetaSkull.field("private GameProfile profile;").setter().reflect();
+            MinecraftClassHandle ResolvableProfile =
+                    ns.ofMinecraft("package nms.world.item.component; public class ResolvableProfile {}");
+
+            boolean useResolvableProfile = CraftMetaSkull.field("private ResolvableProfile profile;").getter().exists();
+
+            if(useResolvableProfile) {
+                newResolvableProfile = ResolvableProfile.constructor("public ResolvableProfile(GameProfile gameProfile);").reflect();
+                getGameProfile = ResolvableProfile.method("public GameProfile gameProfile();")
+                        .named("f")
+                        .reflect();
+
+                profileGetterMeta = CraftMetaSkull.field("private ResolvableProfile profile;").getter().reflect();
+                profileSetterMeta = CraftMetaSkull.method("private void setProfile(ResolvableProfile profile);").reflect();
+            } else {
+                profileGetterMeta = CraftMetaSkull.field("private GameProfile profile;").getter().reflect();
+
+                try {
+                    // https://github.com/CryptoMorin/XSeries/issues/169
+                    // noinspection MethodMayBeStatic
+                    profileSetterMeta = CraftMetaSkull.method("private void setProfile(GameProfile profile);").reflect();
+                } catch (NoSuchMethodException e) {
+                    profileSetterMeta = CraftMetaSkull.field("private GameProfile profile;").setter().reflect();
+                }
             }
 
             MinecraftClassHandle MinecraftServer = ns.ofMinecraft(
@@ -146,7 +163,11 @@ public final class ProfilesCore {
                 "package cb.block; public class CraftSkull extends CraftBlockEntityState implements Skull {}"
         );
 
-        FieldMemberHandle craftProfile = CraftSkull.field("private GameProfile profile;");
+        FieldMemberHandle craftProfile = CraftSkull.field("private ResolvableProfile profile;");
+
+        if(!craftProfile.getter().exists()) {
+            craftProfile = CraftSkull.field("private GameProfile profile;");
+        }
 
         Property_getValue = NULLABILITY_RECORD_UPDATE ? null :
                 ns.of(Property.class).method("public String getValue();").unreflect();
@@ -163,6 +184,8 @@ public final class ProfilesCore {
         CRAFT_META_SKULL_PROFILE_GETTER = profileGetterMeta;
         CRAFT_SKULL_PROFILE_SETTER = craftProfile.setter().unreflect();
         CRAFT_SKULL_PROFILE_GETTER = craftProfile.getter().unreflect();
+        ResolvableProfile_constructor = newResolvableProfile;
+        ResolvableProfile_getGameProfile = getGameProfile;
 
         MinecraftClassHandle UserCacheEntry = GameProfileCache
                 .inner("private static class GameProfileInfo {}")

--- a/src/main/java/com/cryptomorin/xseries/profiles/objects/ProfileContainer.java
+++ b/src/main/java/com/cryptomorin/xseries/profiles/objects/ProfileContainer.java
@@ -68,7 +68,14 @@ public abstract class ProfileContainer<T> implements Profileable {
         @Override
         public void setProfile(GameProfile profile) {
             try {
-                ProfilesCore.CRAFT_META_SKULL_PROFILE_SETTER.invoke(meta, profile);
+                if(ProfilesCore.ResolvableProfile_constructor != null) {
+                    ProfilesCore.CRAFT_META_SKULL_PROFILE_SETTER.invoke(
+                            meta,
+                            ProfilesCore.ResolvableProfile_constructor.invoke(profile)
+                    );
+                } else {
+                    ProfilesCore.CRAFT_META_SKULL_PROFILE_SETTER.invoke(meta, profile);
+                }
             } catch (Throwable throwable) {
                 throw new RuntimeException("Unable to set profile " + profile + " to " + meta, throwable);
             }
@@ -82,7 +89,11 @@ public abstract class ProfileContainer<T> implements Profileable {
         @Override
         public GameProfile getProfile() {
             try {
-                return (GameProfile) ProfilesCore.CRAFT_META_SKULL_PROFILE_GETTER.invoke((SkullMeta) meta);
+                Object profile = ProfilesCore.CRAFT_META_SKULL_PROFILE_GETTER.invoke((SkullMeta) meta);
+                if(ProfilesCore.ResolvableProfile_getGameProfile != null) {
+                    return (GameProfile) ProfilesCore.ResolvableProfile_getGameProfile.invoke(profile);
+                }
+                return (GameProfile) profile;
             } catch (Throwable throwable) {
                 throw new RuntimeException("Failed to get profile from item meta: " + meta, throwable);
             }
@@ -127,7 +138,14 @@ public abstract class ProfileContainer<T> implements Profileable {
         @Override
         public void setProfile(GameProfile profile) {
             try {
-                ProfilesCore.CRAFT_SKULL_PROFILE_SETTER.invoke(state, profile);
+                if(ProfilesCore.ResolvableProfile_constructor != null) {
+                    ProfilesCore.CRAFT_SKULL_PROFILE_SETTER.invoke(
+                            state,
+                            ProfilesCore.ResolvableProfile_constructor.invoke(profile)
+                    );
+                } else {
+                    ProfilesCore.CRAFT_SKULL_PROFILE_SETTER.invoke(state, profile);
+                }
             } catch (Throwable throwable) {
                 throw new RuntimeException("Unable to set profile " + profile + " to " + state, throwable);
             }
@@ -141,7 +159,11 @@ public abstract class ProfileContainer<T> implements Profileable {
         @Override
         public GameProfile getProfile() {
             try {
-                return (GameProfile) ProfilesCore.CRAFT_SKULL_PROFILE_GETTER.invoke(state);
+                Object profile = ProfilesCore.CRAFT_SKULL_PROFILE_GETTER.invoke(state);
+                if(ProfilesCore.ResolvableProfile_getGameProfile != null) {
+                    return (GameProfile) ProfilesCore.ResolvableProfile_getGameProfile.invoke(profile);
+                }
+                return (GameProfile) profile;
             } catch (Throwable throwable) {
                 throw new RuntimeException("Unable to get profile fr om blockstate: " + state, throwable);
             }


### PR DESCRIPTION
Already sometime the ResolvableProfile exists (I think since 1.20.5) but now the GameProfile was replaced with the ResolvableProfile both in the CraftSkull & CraftMetaSkull classes. ResolvableProfile has a constructor accepts only a GameProfile to create a profile from a GameProfile and it also saves a gameProfile that is also created when it's not created with a game profile.

This pr adds two new method handles. One for creating a ResolvableProfile from a GameProfile and one to get the GameProfile back from a ResolvableProfile. I tested myself the changes for my plugins and with my changes it, Skulls (both Items & Blocks) working again on paper build 83.

This would also fix #298

_If I'm honest, I have zero clue how your abstraction over reflection even works and it looks really "magically" and I'm sure I didn't properly followed the current code style, so if you want to implement yourself, just use this pr to see how it works._