### PR TITLE
[XReflection] - ReflectionParser usage of toUpperCase with Locale.ENGLISH

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/reflection/parser/ReflectionParser.java
+++ b/src/main/java/com/cryptomorin/xseries/reflection/parser/ReflectionParser.java
@@ -252,7 +252,7 @@ public class ReflectionParser {
         String flagsStr = group("flags");
 
         for (String flag : flagsStr.split("\\s+")) {
-            if (!flags.add(Flag.valueOf(flag.toUpperCase()))) {
+            if (!flags.add(Flag.valueOf(flag.toUpperCase(Locale.ENGLISH)))) {
                 error("Repeated flag: " + flag);
             }
         }


### PR DESCRIPTION
Added Locale.ENGLISH for parse correct format.

An error occurred when try to parse PUBLIC in Turkish like PUBLİC