### PR TITLE
[XMaterial] Fix NPE when no server is running (during unit tests)

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -2314,11 +2314,15 @@ public enum XMaterial /* implements com.cryptomorin.xseries.abstractions.Materia
         private static final int VERSION;
 
         static { // This needs to be right below VERSION because of initialization order.
-            String version = Bukkit.getVersion();
-            Matcher matcher = Pattern.compile("MC: \\d\\.(\\d+)").matcher(version);
+            if (Bukkit.getServer() == null) {
+                VERSION = 21;
+            } else {
+                String version = Bukkit.getVersion();
+                Matcher matcher = Pattern.compile("MC: \\d\\.(\\d+)").matcher(version);
 
-            if (matcher.find()) VERSION = Integer.parseInt(matcher.group(1));
-            else throw new IllegalArgumentException("Failed to parse server version from: " + version);
+                if (matcher.find()) VERSION = Integer.parseInt(matcher.group(1));
+                else throw new IllegalArgumentException("Failed to parse server version from: " + version);
+            }
         }
 
         /**

--- a/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -2315,6 +2315,7 @@ public enum XMaterial /* implements com.cryptomorin.xseries.abstractions.Materia
 
         static { // This needs to be right below VERSION because of initialization order.
             if (Bukkit.getServer() == null) {
+                System.err.println("Bukkit.getServer() in null. This should not happen when running a plugin normally");
                 VERSION = 21;
             } else {
                 String version = Bukkit.getVersion();


### PR DESCRIPTION
My project has some unit tests that run without starting a Bukkit server. This causes a NullPointerException in `XMaterial` when `Bukkit#getVersion` is called:
```
Caused by: java.lang.NullPointerException: Cannot invoke "org.bukkit.Server.getVersion()" because "org.bukkit.Bukkit.server" is null
	at org.bukkit.Bukkit.getVersion(Bukkit.java:96)
	at com.cryptomorin.xseries.XMaterial$Data.<clinit>(XMaterial.java:2317)
	... 9 more
```
The tests don't actually call any `XMaterial` methods, but the class is initialized by an enum that looks something like this:
```java
VALUE_1("Some string", XMaterial.FURNACE),
VALUE_2("Some other string", XMaterial.CLOCK)
```
This PR aims to fix this by checking if `Bukkit#getServer` is `null` before calling `Bukkit#getVersion`