### PR TITLE
[XBiome] Fix World#getMinHeight Check Setting Wrong Boolean

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/XBiome.java
+++ b/src/main/java/com/cryptomorin/xseries/XBiome.java
@@ -184,7 +184,7 @@ public final class XBiome extends XModule<XBiome, Biome> {
         try {
             // Around v1.17.0
             World.class.getMethod("getMinHeight");
-            maxHeight = true;
+            minHeight = true;
         } catch (Exception ignored) {
         }
         World_getMaxHeight$SUPPORTED = maxHeight;


### PR DESCRIPTION
Fixes: #319

Fix a typo of setting maxHeight rather than the minHeight value in the World#getMinHeight check.