### PR TITLE
expose the form classes

### DIFF
--- a/src/main/java/com/cryptomorin/xseries/base/XRegistry.java
+++ b/src/main/java/com/cryptomorin/xseries/base/XRegistry.java
@@ -150,6 +150,20 @@ public final class XRegistry<XForm extends XBase<XForm, BukkitForm>, BukkitForm>
     }
 
     /**
+     * Gets the class of the bukkit form.
+     */
+    public Class<BukkitForm> getBukkitFormClass() {
+        return bukkitFormClass;
+    }
+
+    /**
+     * Gets the class of the xform.
+     */
+    public Class<XForm> getXFormClass() {
+        return xFormClass;
+    }
+
+    /**
      * Gets the name of the registry, which is usually the bukkit form's simple class name.
      */
     public String getName() {


### PR DESCRIPTION
Having this data solves some minor problems for me. Being able to get the types is good when we want to wrap your generics with our own generics (if we do anything fancy). 

This PR just adds getters for the types already stored in `XRegistry`