### PR TITLE
Fixed issues with XMaterial not working correctly on modern versions

### DIFF
--- a/core/.flattened-pom.xml
+++ b/core/.flattened-pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2025 Crypto Morin
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  ~ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+  ~ PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+  ~ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+  ~ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.github.cryptomorin</groupId>
+  <artifactId>XSeries</artifactId>
+  <version>13.1.0</version>
+  <name>XSeries</name>
+  <description>A set of utilities for Minecraft plugins</description>
+  <url>https://www.spigotmc.org/threads/378136/XSeries/</url>
+  <inceptionYear>2019</inceptionYear>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>CryptoMorin</id>
+      <name>Crypto Morin</name>
+      <roles>
+        <role>Owner</role>
+      </roles>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:svn:http://svn.sonatype.org/spice/trunk/oss/oss-parenti-9/parent/XSeries</connection>
+    <developerConnection>scm:svn:https://svn.sonatype.org/spice/trunk/oss/oss-parent-9/parent/XSeries</developerConnection>
+    <url>http://svn.sonatype.org/spice/trunk/oss/oss-parent-9/parent/XSeries</url>
+  </scm>
+  <issueManagement>
+    <system>GitHub Issues</system>
+    <url>https://github.com/CryptoMorin/XSeries/issues</url>
+  </issueManagement>
+  <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.github.cryptomorin</groupId>
+      <artifactId>commons</artifactId>
+      <version>13.1.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.cryptomorin</groupId>
+      <artifactId>new-bukkit</artifactId>
+      <version>13.1.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.cryptomorin</groupId>
+      <artifactId>old-bukkit</artifactId>
+      <version>13.1.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.spigotmc</groupId>
+      <artifactId>spigot</artifactId>
+      <version>1.21.4-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>26.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.7.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>9.7.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>9.7.1</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>nms-repo</id>
+      <url>https://repo.codemc.org/repository/nms/</url>
+    </repository>
+    <repository>
+      <id>minecraft-libraries</id>
+      <name>Minecraft Libraries</name>
+      <url>https://libraries.minecraft.net/</url>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.7.0</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -123,10 +123,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-toolchains-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <!-- We use this to collect submodules -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -148,10 +144,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>

--- a/core/src/main/java/com/cryptomorin/xseries/XMaterial.java
+++ b/core/src/main/java/com/cryptomorin/xseries/XMaterial.java
@@ -1842,6 +1842,10 @@ public enum XMaterial implements XBase<XMaterial, Material> {
             }
         }
 
+        if (Data.getExactMaterial(name()) != null) {
+            mat = Data.getExactMaterial(name());
+        }
+
         this.material = mat;
     }
 
@@ -1850,7 +1854,7 @@ public enum XMaterial implements XBase<XMaterial, Material> {
     }
 
     /**
-     * Gets the XMaterial with this name similar to {@link #valueOf(String)}
+     * Gets the XMaterial with this name similar to
      * without throwing an exception.
      *
      * @param name the name of the material.

--- a/pom.xml
+++ b/pom.xml
@@ -130,19 +130,8 @@
                     <artifactId>maven-toolchains-plugin</artifactId>
                     <version>3.2.0</version>
                     <executions>
-                        <execution>
-                            <phase>validate</phase>
-                            <goals>
-                                <goal>toolchain</goal>
-                            </goals>
-                        </execution>
                     </executions>
                     <configuration>
-                        <toolchains>
-                            <jdk>
-                                <version>[${testJava}]</version>
-                            </jdk>
-                        </toolchains>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -209,20 +198,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.2.7</version>
-                    <executions>
-                        <execution>
-                            <id>sign-artifacts</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>sign</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>1.7.0</version>
@@ -269,7 +244,7 @@
 
                                 <!-- As of Java 21, annotation processing is disabled by default. -->
                                 <!-- <compilerArgs><arg>-proc:full</arg></compilerArgs> -->
-                                <proc>full</proc>
+<!--                                <proc>full</proc>-->
 
                                 <annotationProcessorPaths>
                                     <path>
@@ -303,9 +278,6 @@
                         <!-- <jvm>${testJavaPath}</jvm>-->
                         <!-- You can also use the following argument from the cmd line: -->
                         <!-- <dash><dash>toolchains "\.m2\toolchains.xml" -->
-                        <jdkToolchain>
-                            <version>[${testJava}]</version>
-                        </jdkToolchain>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Basically, I had the issue that, for example, stuff like RED_DYE would be displayed as INC_SACK on newer versions, so I just made a small change to see if the newer material exists; then it should be used instead.