### PR TITLE
[ParticleDisplay] Ensure 'extra' isn't 0 when setting note color

### DIFF
--- a/core/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/core/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -1644,9 +1644,14 @@ public class ParticleDisplay {
         double dx = offset.getX();
         double dy = offset.getY();
         double dz = offset.getZ();
-        // The "extra" field has no effect on dust particles in some versions,
-        // but in others it causes the colors to not display when set to 0.
-        double extra = (this.particle == XParticle.DUST) ? 1 : this.extra;
+        double extra = this.extra;
+        if (this.particle == XParticle.DUST || this.particle == XParticle.NOTE) {
+            // The "extra" field has no effect on dust particles in some versions,
+            // but in others it causes the colors to not display when set to 0.
+            // For note particles, the rendered color is dx * extra, so we just
+            // always put the color in dx and set extra to 1.
+            extra = 1;
+        }
         if (players == null)
             if (ISFLAT)
                 loc.getWorld().spawnParticle(particle, loc, count, dx, dy, dz, extra, data, force);


### PR DESCRIPTION
You would expect this code to produce a purple music note (according to the table [here](https://minecraft.wiki/w/Note_Block#Notes)):
```java
ParticleDisplay.of(XParticle.NOTE).withColor(12).spawn(loc);
```
But as it stands, you only get green, no matter what color you put in, due to `extra` defaulting to 0. For whatever reason, `extra` is multiplied by the first offset field (the place where the note color is typically stored) and so if either is 0, you only get green notes back. So the working code is this:
```java
ParticleDisplay.of(XParticle.NOTE).withColor(12).withExtra(1).spawn(loc);
```

That's definitely unexpected if you're not already used to the weirdness of the particle system, and perhaps even if you are. So, to resolve confusion, I've added a check to ensure `extra` is not 0 when setting the note color. This parallels what ParticleDisplay already does in `particleDirection` and `spawnRaw` for dust particles.