### PR TITLE
[Titles] Fix ClassCastException caused by packet sending in newer versions

### DIFF
--- a/core/src/main/java/com/cryptomorin/xseries/messages/Titles.java
+++ b/core/src/main/java/com/cryptomorin/xseries/messages/Titles.java
@@ -244,7 +244,7 @@ public final class Titles {
                 throw new RuntimeException(e);
             }
 
-            MinecraftConnection.sendPacket(player, packets);
+            MinecraftConnection.sendPacket(player, packets.toArray(new Object[0]));
             return;
         }
 


### PR DESCRIPTION
`MinecraftConnection#sendPacket(Player, Object...)` expects a varargs list of individual packet objects, however currently `Titles.sendTitle(Player, int, int, int, MessageText, MessageText)` passes the packets list directly

Fixes #347