### PR TITLE
[XReflection] Update obfuscated mapping for 1.21.7 player connection

### DIFF
--- a/core/src/main/java/com/cryptomorin/xseries/reflection/minecraft/MinecraftConnection.java
+++ b/core/src/main/java/com/cryptomorin/xseries/reflection/minecraft/MinecraftConnection.java
@@ -66,7 +66,7 @@ public final class MinecraftConnection {
             .field().getter()
             .returns(ServerGamePacketListenerImpl)
             .map(MinecraftMapping.MOJANG, "connection")
-            .map(MinecraftMapping.OBFUSCATED, v(21, 2, "f").v(20, "c").v(17, "b").orElse("playerConnection"))
+            .map(MinecraftMapping.OBFUSCATED, v(21, 7, "g").v(21, 2, "f").v(20, "c").v(17, "b").orElse("playerConnection"))
             .unreflect();
     /**
      * Responsible for getting the NMS handler {@code EntityPlayer} object for the player.


### PR DESCRIPTION
In 1.21.7 the obfuscated mapping for the `connection` field was changed from `f` to `g`

- [Previously (1.21.5)](https://mappings.dev/1.21.5/net/minecraft/server/level/ServerPlayer.html)
<img width="1000" height="150" src="https://github.com/user-attachments/assets/edf599b7-e706-477f-91d3-9a722e175150" />

- [1.21.7](https://mappings.dev/1.21.7/net/minecraft/server/level/ServerPlayer.html)
<img width="1000" height="150" src="https://github.com/user-attachments/assets/6cf4636d-fc77-411c-96fb-2de6a7e5920e" />
