### PR TITLE
JitPack Fix: Auto-discover JDK toolchain instead of requiring explicit toolchains.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.cryptomorin</groupId>
@@ -133,16 +133,13 @@
                         <execution>
                             <phase>validate</phase>
                             <goals>
-                                <goal>toolchain</goal>
+                                <goal>display-discovered-jdk-toolchains</goal>
+                                <goal>select-jdk-toolchain</goal>
                             </goals>
                         </execution>
                     </executions>
                     <configuration>
-                        <toolchains>
-                            <jdk>
-                                <version>[${testJava}]</version>
-                            </jdk>
-                        </toolchains>
+                        <version>[${testJava},)</version>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -415,21 +412,21 @@
                     <extensions>true</extensions>
                     <configuration>
                         <publishingServerId>central</publishingServerId>
-<!--                        <autoPublish>true</autoPublish>-->
-<!--                        <waitUntil>published</waitUntil>-->
+                        <!--                        <autoPublish>true</autoPublish>-->
+                        <!--                        <waitUntil>published</waitUntil>-->
                     </configuration>
                 </plugin>
-<!--                <plugin>-->
-<!--                    <groupId>org.sonatype.plugins</groupId>-->
-<!--                    <artifactId>nexus-staging-maven-plugin</artifactId>-->
-<!--                    <version>1.7.0</version>-->
-<!--                    <extensions>true</extensions>-->
-<!--                    <configuration>-->
-<!--                        <serverId>ossrh</serverId>-->
-<!--                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>-->
-<!--                        <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
-<!--                    </configuration>-->
-<!--                </plugin>-->
+                <!--                <plugin>-->
+                <!--                    <groupId>org.sonatype.plugins</groupId>-->
+                <!--                    <artifactId>nexus-staging-maven-plugin</artifactId>-->
+                <!--                    <version>1.7.0</version>-->
+                <!--                    <extensions>true</extensions>-->
+                <!--                    <configuration>-->
+                <!--                        <serverId>ossrh</serverId>-->
+                <!--                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>-->
+                <!--                        <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
+                <!--                    </configuration>-->
+                <!--                </plugin>-->
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This fixes JitPack builds and streamlines collaboration by automatically discovering and selecting a JDK toolchain with JDK version ${testJava} (or above). Explicit toolchain declaration in ~/.m2/toolchains.xml is no longer required for new collaborators, and the automatic selection also prevents tools like JitPack from mysteriously attempting to find a Java 6 path (https://github.com/CryptoMorin/XSeries/issues/329).

Successful JitPack build with this change: [https://jitpack.io/com/github/demengc/XSeries/ed391d7c76/build.log](https://jitpack.io/com/github/demengc/XSeries/ed391d7c76/build.log)

Additional information on automatic discovery of JDK toolchains (new in Apache maven-toolchains-plugin v3.2.0): https://github.com/apache/maven-toolchains-plugin/pull/14 / https://maven.apache.org/plugins/maven-toolchains-plugin/select-jdk-toolchain-mojo.html