### PR TITLE
[XItemStack] Copy item in XItemStack.Deserializer#copy

### DIFF
--- a/core/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/core/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -1009,7 +1009,7 @@ public final class XItemStack {
         @Override
         public Deserializer copy() {
             return new Deserializer()
-                    .withItem(item)
+                    .withItem(item == null ? null : item.clone())
                     .withConfig(config)
                     .withTranslator(translator)
                     .withRestart(restart)


### PR DESCRIPTION
Minor change to adjust a surprising behavior I encountered with `XItemStack.Deserializer`. Previously:

```java
XItemStack.Deserializer deserializer = XItemStack.deserializer().withTranslator(mySpecialTranslator);
ItemStack a = deserializer.copy().withConfig(aConfig).read();
ItemStack b = deserializer.copy().withConfig(bConfig).read();
// `a` and `b` now refer to the same instance of ItemStack!
assert a == b;
// The properties loaded from `aConfig` are nowhere to be found
```

I've now changed it so `copy()` also `clone()`s the item, so copied deserializers get their own copy of the item. This does leave open the same issue if you don't use `copy()` though:

```java
XItemStack.Deserializer deserializer = XItemStack.deserializer().withTranslator(mySpecialTranslator);
ItemStack a = deserializer.withConfig(aConfig).read();
ItemStack b = deserializer.withConfig(bConfig).read();
assert a == b;
```

Perhaps it would be worth adding another `item.clone()` somewhere to avoid this potentially surprising behavior? Although I suppose you might want to be able to do this:

```java
ItemStack mySpecialItem = /* some item stack with fancy lore and stuff */;
XItemStack.deserializer().withItem(mySpecialItem).withConfig(myConfig).read();
// mySpecialItem is now updated with the contents of myConfig,
// though the name `read()` doesn't make that super obvious to me
```