### PR TITLE
[ParticleDisplay] Add support for Particle.Spell

### DIFF
--- a/core/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
+++ b/core/src/main/java/com/cryptomorin/xseries/particles/ParticleDisplay.java
@@ -1719,11 +1719,9 @@ public class ParticleDisplay {
             if (particle.getDataType() == Float.class) {
                 data = 1f;
             } else if (particle.getDataType() == org.bukkit.Color.class) {
-                if (particle == XParticle.DUST.get()) {
-                    data = org.bukkit.Color.RED;
-                } else {
-                    data = randomColor();
-                }
+                data = randomColor();
+            } else if (particle.getDataType() == Particle.DustOptions.class) {
+                data = new Particle.DustOptions(org.bukkit.Color.RED, 1f);
             } else if (SUPPORTS_SPELL_DATA && particle.getDataType() == Particle.Spell.class) {
                 data = new Particle.Spell(randomColor(), 1);
             }


### PR DESCRIPTION
As of 1.21.9, the particles `EFFECT` and `EFFECT_INSTANT` require the `Particle.Spell` class to be provided instead of using `Color` or something. This PR adds compatibility for that using the existing `withColor` API.

Changes:
- New constants, `SUPPORTS_SPELL_DATA` and `SUPPORTS_DUST_TRANSITION`
- Serialization/deserialization of `RGBParticleColor` now includes the alpha channel, since `ENTITY_EFFECT` does use the alpha channel since 1.20.4 or so.
- `withColor` now avoids unnecessary conversion to raw r/g/b numbers when possible to retain the alpha channel if it's set.
- Removed the `* 4` on the offset calculator, it's more accurate to vanilla behavior without.
- Some particles now have default data for usability. This also reflects the way they were handled in older versions. For example, a potion swirl particle spawned without color data used to be a random color; now, ParticleDisplay does that as well.
- Selection of Bukkit particle data is now done based on `Particle#getDataType` rather than switching on the name of the particle. This is especially important now that the data type of a particle can depend on the server version.

Did some testing in 1.9.4, 1.17.1, and 1.21.11 and it seemed to work as expected, though I ran out of time to be as thorough as I wanted.