### PR TITLE
[XItemStack] Fixes issue with potions & adds item name support

### DIFF
--- a/core/src/main/java/com/cryptomorin/xseries/XItemStack.java
+++ b/core/src/main/java/com/cryptomorin/xseries/XItemStack.java
@@ -570,9 +570,9 @@ public final class XItemStack {
             // Display Name & Lore
             if (meta.hasDisplayName()) {
                 if (miniMessageHandler != null) {
-                    config.set("display_name", AdventureAPIFactory.displayName(meta, miniMessageHandler));
+                    config.set("name", AdventureAPIFactory.displayName(meta, miniMessageHandler));
                 } else {
-                    config.set("display_name", translator.apply(meta.getDisplayName()));
+                    config.set("name", translator.apply(meta.getDisplayName()));
                 }
             }
             if (meta.hasLore()) {
@@ -585,7 +585,7 @@ public final class XItemStack {
 			
 			if (SUPPORTS_ITEM_NAME && meta.hasItemName()) {
 				String itemName = meta.getItemName();
-				config.set("item_name", translator.apply(itemName));
+				config.set("item-name", translator.apply(itemName));
 			}
 
             customModelData();
@@ -1203,7 +1203,7 @@ public final class XItemStack {
 
         @SuppressWarnings("ConstantValue")
         private void displayName() {
-            String name = config.getString("display_name");
+            String name = config.getString("name");
 
             if (!Strings.isNullOrEmpty(name)) {
                 if (miniMessageHandler != null) {
@@ -1223,7 +1223,7 @@ public final class XItemStack {
 			if (!SUPPORTS_ITEM_NAME)
 				return;
 
-			String itemName = config.getString("item_name");
+			String itemName = config.getString("item-name");
 			if (!Strings.isNullOrEmpty(itemName)) {
 				String translated = translator.apply(itemName);
 				meta.setItemName(translated);


### PR DESCRIPTION
I added support for item name and also fixed the error with deserializing potions. I also found that the serializer writes the internal values (ticks & 0-based amplifier), but the deserializer assumes it is reading seconds and 1-based levels.

Also, I did go ahead and add something to serialize custom_data tags/ item components using the library NBTEditor, which you can remove if you don't want it

Thanks! :)

Closes #387
Closes #388 

Whoops I forgot to delete a semi-colon xD